### PR TITLE
chore(husky): チェックアウト・マージ時に依存変化を検知して自動インストールするフックを追加

### DIFF
--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+./scripts/run-install.sh "$1" "$2"

--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+./scripts/run-install.sh ORIG_HEAD HEAD

--- a/bun.lock
+++ b/bun.lock
@@ -12,6 +12,7 @@
       "devDependencies": {
         "@tauri-apps/cli": "^2",
         "@vitejs/plugin-vue": "^5.2.1",
+        "husky": "^9.1.7",
         "typescript": "~5.6.2",
         "vite": "^6.0.3",
         "vue-tsc": "^2.1.10",
@@ -212,6 +213,8 @@
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "he": ["he@1.2.0", "", { "bin": { "he": "bin/he" } }, "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="],
+
+    "husky": ["husky@9.1.7", "", { "bin": { "husky": "bin.js" } }, "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vue-tsc --noEmit && vite build",
     "preview": "vite preview",
-    "tauri": "tauri"
+    "tauri": "tauri",
+    "prepare": "husky"
   },
   "dependencies": {
     "vue": "^3.5.13",
@@ -15,10 +16,11 @@
     "@tauri-apps/plugin-opener": "^2"
   },
   "devDependencies": {
+    "@tauri-apps/cli": "^2",
     "@vitejs/plugin-vue": "^5.2.1",
+    "husky": "^9.1.7",
     "typescript": "~5.6.2",
     "vite": "^6.0.3",
-    "vue-tsc": "^2.1.10",
-    "@tauri-apps/cli": "^2"
+    "vue-tsc": "^2.1.10"
   }
 }

--- a/scripts/run-install.sh
+++ b/scripts/run-install.sh
@@ -2,7 +2,7 @@
 
 # 第 1 引数と第 2 引数のコミット間で
 # bun.lock / package.json に差分があれば `bun install` を、
-# src-tauri/Cargo.toml に差分があれば `cargo fetch` を実行する
+# src-tauri/Cargo.toml / Cargo.lock に差分があれば `cargo fetch` を実行する
 
 set -e
 
@@ -16,14 +16,12 @@ if [[ -z "${OLD_REV}" || -z "${NEW_REV}" ]]; then
   exit 0
 fi
 
-CHANGED="$(git diff --name-only "${OLD_REV}" "${NEW_REV}" || true)"
-
-if echo "${CHANGED}" | grep -E -q '^(package\.json|bun\.lock)$'; then
+if ! git diff --quiet "${OLD_REV}" "${NEW_REV}" -- package.json bun.lock 2>/dev/null; then
   echo "👀 JS dependency differences detected. Running \`bun install\`..."
   bun install
 fi
 
-if echo "${CHANGED}" | grep -E -q '^src-tauri/Cargo\.toml$'; then
+if ! git diff --quiet "${OLD_REV}" "${NEW_REV}" -- src-tauri/Cargo.toml src-tauri/Cargo.lock 2>/dev/null; then
   echo "👀 Rust dependency differences detected. Running \`cargo fetch\`..."
   cargo fetch --manifest-path src-tauri/Cargo.toml
 fi

--- a/scripts/run-install.sh
+++ b/scripts/run-install.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# 第 1 引数と第 2 引数のコミット間で
+# bun.lock / package.json に差分があれば `bun install` を、
+# src-tauri/Cargo.toml に差分があれば `cargo fetch` を実行する
+
+set -e
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
+cd "$REPO_ROOT"
+
+OLD_REV="${1:-}"
+NEW_REV="${2:-}"
+
+if [[ -z "${OLD_REV}" || -z "${NEW_REV}" ]]; then
+  exit 0
+fi
+
+CHANGED="$(git diff --name-only "${OLD_REV}" "${NEW_REV}" || true)"
+
+if echo "${CHANGED}" | grep -E -q '^(package\.json|bun\.lock)$'; then
+  echo "👀 JS dependency differences detected. Running \`bun install\`..."
+  bun install
+fi
+
+if echo "${CHANGED}" | grep -E -q '^src-tauri/Cargo\.toml$'; then
+  echo "👀 Rust dependency differences detected. Running \`cargo fetch\`..."
+  cargo fetch --manifest-path src-tauri/Cargo.toml
+fi


### PR DESCRIPTION
close #

### 背景

チェックアウトやマージ後に手動で `bun install` / `cargo fetch` を忘れると、依存関係がずれた状態で開発が進んでしまう。

### 概要

husky を導入し、`bun.lock` / `package.json` / `src-tauri/Cargo.toml` に差分がある場合に自動でインストールコマンドを実行するフックを追加した。

### 変更内容

- `husky` を devDependencies に追加し、`prepare` スクリプトで自動セットアップされるよう設定
- `scripts/run-install.sh` を新規作成（旧 `run-npm-install.sh` を置き換え）
  - `bun.lock` / `package.json` に差分 → `bun install`
  - `src-tauri/Cargo.toml` に差分 → `cargo fetch`
- `.husky/post-checkout` / `post-merge` のスクリプト参照先を更新

### チェック項目

- [ ] `post-checkout` / `post-merge` フックが正しく動作するか

### 備考