### PR TITLE
ci: PR 時に Lint・Format・Build を検証する Actions を導入

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,14 @@ jobs:
         with:
           components: clippy, rustfmt
 
+      - name: Install Tauri System Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev
+
       - name: Cache Cargo
         uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,71 @@
+name: CI
+
+on:
+  pull_request:
+
+jobs:
+  lint:
+    name: Lint (JS/TS)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install Dependencies
+        run: bun install
+
+      - name: ESLint
+        run: bun run lint
+
+      - name: Stylelint
+        run: bun run lint:style
+
+      - name: Oxfmt
+        run: bun run format:check
+
+  lint-rust:
+    name: Lint (Rust)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - name: Cache Cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Clippy
+        run: cargo clippy -- -D warnings
+        working-directory: src-tauri
+
+      - name: rustfmt
+        run: cargo fmt --check
+        working-directory: src-tauri
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install Dependencies
+        run: bun install
+
+      - name: Build
+        run: bun run build


### PR DESCRIPTION
close #

### 概要

PR 作成時に自動でコード品質を検証する GitHub Actions ワークフローを導入した。

### 変更内容

- **Lint（JS/TS）ジョブ**
  - `bun run lint`（ESLint）
  - `bun run lint:style`（Stylelint）
  - `bun run format:check`（Oxfmt）
- **Lint（Rust）ジョブ**
  - Clippy（`-D warnings` で警告をエラー扱い）
  - rustfmt（フォーマット確認）
  - `Swatinem/rust-cache` で Cargo キャッシュ
- **Build ジョブ**
  - `bun run build`（`vue-tsc --noEmit` + Vite ビルド）

### チェック項目

- [ ] 3 つのジョブがすべて green になること

### 備考

- Rust の Lint は実行時間が長いため pre-commit フックには含めず CI 専用とした
- パッケージマネージャーは bun（`oven-sh/setup-bun@v2`）を使用