### PR TITLE
feat: グローバルキーストローク計測・SQLite 保存機能を実装

### DIFF
--- a/.claude/rules/comment.md
+++ b/.claude/rules/comment.md
@@ -7,11 +7,13 @@
 - 対話後の修正時に修正箇所に関する説明をコメントで強調しない（コードの最終的な読み手はその経緯を知らない）
 - コメントの量はその影響範囲、つまりどれだけ多くの場所から呼び出されるかに依存する
   - 他の場所から呼び出されうる定数・関数は丁寧に説明する
-  - 関数は JSDoc に近い書き方を心がける
+  - TypeScript の関数は JSDoc スタイルを、Rust の関数は Rustdoc スタイルを使う
 
 ## コメントの例
 
-### 型定義
+### TypeScript
+
+#### 型定義
 
 ```typescript
 // src/types/user.ts
@@ -34,7 +36,7 @@ export type Address = {
 };
 ```
 
-### 関数定義
+#### 関数定義
 
 ```typescript
 /**
@@ -61,4 +63,39 @@ export const formatOrderItems = async (
 ): Promise<Partial<OrderItems> | null> => {
   ...
 };
+```
+
+### Rust
+
+- `///` で記述する（`/** */` は使わない）
+- `@param` / `@returns` は使わない（JSDoc 記法は Rustdoc に認識されない）
+- `# Section` 見出しを使う。`cargo doc` でレンダリングされる
+- よく使うセクション:
+  - `# Parameters` — 引数の説明
+  - `# Returns` — 返り値の説明
+  - `# Errors` — `Result::Err` になる条件
+  - `# Panics` — パニックする条件
+  - `# Behavior` — 動作の詳細・注意事項
+  - `# Examples` — 使用例（`cargo test` で実行される）
+
+#### 関数定義
+
+```rust
+/// `minute_count` の現在値を SQLite に保存し、保存成功時に減算・`today_db_count` を加算する
+///
+/// # Parameters
+/// * `minute_count` - 直近の未保存キーストローク数
+/// * `today_db_count` - 今日の DB 保存済み合計（書き込み成功時にインクリメントされる）
+/// * `db_path` - データベースファイルのパス
+///
+/// # Behavior
+/// * `minute_count` が 0 の場合は書き込みをスキップする
+/// * DB 書き込み成功後に保存した分だけ減算する（失敗時はカウントを保持）
+fn flush_minute_count(
+    minute_count: &Arc<Mutex<u64>>,
+    today_db_count: &Arc<Mutex<u64>>,
+    db_path: &str,
+) {
+    ...
+}
 ```

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -9,6 +9,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -256,6 +268,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "block"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -451,9 +469,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "cocoa"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "667fdc068627a2816b9ff831201dd9864249d6ee8d190b9532357f1fc0f61ea7"
+dependencies = [
+ "bitflags 1.3.2",
+ "block",
+ "core-foundation 0.9.4",
+ "core-graphics 0.21.0",
+ "foreign-types 0.3.2",
+ "libc",
+ "objc",
 ]
 
 [[package]]
@@ -487,13 +522,39 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171"
+dependencies = [
+ "core-foundation-sys 0.7.0",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys 0.8.7",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
- "core-foundation-sys",
+ "core-foundation-sys 0.8.7",
  "libc",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 
 [[package]]
 name = "core-foundation-sys"
@@ -503,14 +564,38 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core-graphics"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3889374e6ea6ab25dba90bb5d96202f61108058361f6dc72e8b03e6f8bbe923"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.7.0",
+ "foreign-types 0.3.2",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52a67c4378cf203eace8fb6567847eb641fd6ff933c1145a115c6ee820ebb978"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.4",
+ "foreign-types 0.3.2",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
 dependencies = [
  "bitflags 2.11.1",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
 ]
 
@@ -521,7 +606,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
  "bitflags 2.11.1",
- "core-foundation",
+ "core-foundation 0.10.1",
  "libc",
 ]
 
@@ -922,6 +1007,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -982,12 +1079,21 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared",
+ "foreign-types-shared 0.3.1",
 ]
 
 [[package]]
@@ -1000,6 +1106,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -1401,6 +1513,15 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -1413,6 +1534,15 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "heck"
@@ -1537,7 +1667,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
 dependencies = [
  "android_system_properties",
- "core-foundation-sys",
+ "core-foundation-sys 0.8.7",
  "iana-time-zone-haiku",
  "js-sys",
  "log",
@@ -1865,6 +1995,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1929,6 +2065,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1954,6 +2101,15 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "markup5ever"
@@ -2094,6 +2250,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "objc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+dependencies = [
+ "malloc_buf",
 ]
 
 [[package]]
@@ -2707,6 +2872,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
+name = "rdev"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00552ca2dc2f93b84cd7b5581de49549411e4e41d89e1c691bcb93dc4be360c3"
+dependencies = [
+ "cocoa",
+ "core-foundation 0.7.0",
+ "core-foundation-sys 0.7.0",
+ "core-graphics 0.19.2",
+ "lazy_static",
+ "libc",
+ "winapi",
+ "x11",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2807,6 +2988,20 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags 2.11.1",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]
@@ -3313,8 +3508,8 @@ checksum = "1cf65722394c2ac443e80120064987f8914ee1d4e4e36e63cdf10f2990f01159"
 dependencies = [
  "bitflags 2.11.1",
  "block2",
- "core-foundation",
- "core-graphics",
+ "core-foundation 0.10.1",
+ "core-graphics 0.25.0",
  "crossbeam-channel",
  "dbus",
  "dispatch2",
@@ -3978,6 +4173,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 name = "typemeter"
 version = "0.1.0"
 dependencies = [
+ "chrono",
+ "rdev",
+ "rusqlite",
  "serde",
  "serde_json",
  "tauri",
@@ -4109,6 +4307,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version-compare"
@@ -5021,6 +5225,26 @@ dependencies = [
  "serde",
  "winnow 1.0.2",
  "zvariant",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -22,4 +22,7 @@ tauri = { version = "2", features = [] }
 tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+rdev = "0.5"
+rusqlite = { version = "0.32", features = ["bundled"] }
+chrono = "0.4"
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,14 +1,106 @@
-// Learn more about Tauri commands at https://tauri.app/develop/calling-rust/
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::Duration;
+
+use chrono::Local;
+use rusqlite::{params, Connection};
+use tauri::{Emitter, Manager, State};
+
+struct DbPath(String);
+
+fn init_db(db_path: &str) {
+    let conn = Connection::open(db_path).expect("failed to open database");
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS keystroke_logs (
+            id           INTEGER PRIMARY KEY AUTOINCREMENT,
+            recorded_at  TEXT    NOT NULL,
+            minute_count INTEGER NOT NULL
+        )",
+    )
+    .expect("failed to initialize database schema");
+}
+
 #[tauri::command]
-fn greet(name: &str) -> String {
-    format!("Hello, {}! You've been greeted from Rust!", name)
+fn get_today_count(db_path: State<DbPath>) -> u64 {
+    let Ok(conn) = Connection::open(&db_path.0) else {
+        return 0;
+    };
+    let today = Local::now().format("%Y-%m-%d").to_string();
+    conn.query_row(
+        "SELECT COALESCE(SUM(minute_count), 0) FROM keystroke_logs WHERE recorded_at LIKE ?1",
+        params![format!("{}%", today)],
+        |row| row.get::<_, i64>(0),
+    )
+    .unwrap_or(0)
+    .max(0) as u64
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
-        .invoke_handler(tauri::generate_handler![greet])
+        .setup(|app| {
+            let db_dir = app
+                .path()
+                .app_data_dir()
+                .expect("failed to get app data dir");
+            std::fs::create_dir_all(&db_dir)?;
+            let db_path = db_dir.join("keystroke.db").to_string_lossy().into_owned();
+
+            init_db(&db_path);
+
+            let session_count = Arc::new(Mutex::new(0u64));
+            let minute_count = Arc::new(Mutex::new(0u64));
+
+            app.manage(DbPath(db_path.clone()));
+
+            // rdev keyboard listener
+            let session_count_rdev = session_count.clone();
+            let minute_count_rdev = minute_count.clone();
+            thread::spawn(move || {
+                rdev::listen(move |event| {
+                    if matches!(event.event_type, rdev::EventType::KeyPress(_)) {
+                        *session_count_rdev.lock().unwrap() += 1;
+                        *minute_count_rdev.lock().unwrap() += 1;
+                    }
+                })
+                .expect("failed to start keyboard listener");
+            });
+
+            // emit session count to frontend every second
+            let session_count_emit = session_count.clone();
+            let app_handle = app.handle().clone();
+            thread::spawn(move || loop {
+                thread::sleep(Duration::from_secs(1));
+                let count = *session_count_emit.lock().unwrap();
+                let _ = app_handle.emit("keystroke_update", count);
+            });
+
+            // persist minute count to SQLite every minute
+            let minute_count_save = minute_count.clone();
+            let db_path_save = db_path.clone();
+            thread::spawn(move || loop {
+                thread::sleep(Duration::from_secs(60));
+                let count = {
+                    let mut lock = minute_count_save.lock().unwrap();
+                    let c = *lock;
+                    *lock = 0;
+                    c
+                };
+                if count > 0 {
+                    if let Ok(conn) = Connection::open(&db_path_save) {
+                        let recorded_at = Local::now().to_rfc3339();
+                        let _ = conn.execute(
+                            "INSERT INTO keystroke_logs (recorded_at, minute_count) VALUES (?1, ?2)",
+                            params![recorded_at, count as i64],
+                        );
+                    }
+                }
+            });
+
+            Ok(())
+        })
+        .invoke_handler(tauri::generate_handler![get_today_count])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -100,20 +100,25 @@ pub fn run() {
             *today_db_count_s.lock().unwrap() = query_today_db_count(&db_path);
             app.manage(DbPath(db_path.clone()));
 
-            // グローバルキーボードイベントのリスニング
+            // グローバルキーボードイベントのリスニング（キー押下時に即 emit）
             let mc_rdev = minute_count_s.clone();
-            let app_handle_rdev = app.handle().clone();
+            let tdc_rdev = today_db_count_s.clone();
+            let app_handle_rdev_emit = app.handle().clone();
+            let app_handle_rdev_err = app.handle().clone();
             thread::spawn(move || {
                 if let Err(e) = rdev::listen(move |event| {
                     if matches!(event.event_type, rdev::EventType::KeyPress(_)) {
                         *mc_rdev.lock().unwrap() += 1;
+                        let today_total =
+                            *tdc_rdev.lock().unwrap() + *mc_rdev.lock().unwrap();
+                        let _ = app_handle_rdev_emit.emit("keystroke_update", today_total);
                     }
                 }) {
-                    let _ = app_handle_rdev.emit("listener_error", format!("{e:?}"));
+                    let _ = app_handle_rdev_err.emit("listener_error", format!("{e:?}"));
                 }
             });
 
-            // today_total を 1 秒ごとにフロントエンドへ emit（日付変更も検知）
+            // ハートビート：初期表示・日付変更検知のため 1 秒ごとに emit
             let mc_emit = minute_count_s.clone();
             let tdc_emit = today_db_count_s.clone();
             let app_handle = app.handle().clone();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -27,7 +27,7 @@ fn init_db(db_path: &str) {
     .expect("failed to initialize database schema");
 }
 
-/// `minute_count` の現在値を SQLite に保存し、保存成功時に減算・`today_db_count` を加算する
+/// `minute_count` の現在値を SQLite に保存し、保存成功時に `today_db_count` を加算する
 ///
 /// # Parameters
 /// * `minute_count` - 直近の未保存キーストローク数
@@ -36,28 +36,37 @@ fn init_db(db_path: &str) {
 ///
 /// # Behavior
 /// * `minute_count` が 0 の場合は書き込みをスキップする
-/// * DB 書き込み成功後に保存した分だけ減算する（失敗時はカウントを保持）
-/// * 書き込み中に増加した分は `saturating_sub` により正しく保持される
+/// * ロック取得と同時にカウントを 0 にして「書き込み権」を確保し、IO 中の二重保存を防ぐ
+/// * DB 書き込み失敗時はカウントを加算して戻す
 /// * 1 分タイマーとアプリ終了時の両方から呼び出される
 fn flush_minute_count(
     minute_count: &Arc<Mutex<u64>>,
     today_db_count: &Arc<Mutex<u64>>,
     db_path: &str,
 ) {
-    let count = *minute_count.lock().unwrap();
-    if count > 0 {
-        if let Ok(conn) = Connection::open(db_path) {
-            let recorded_at = Local::now().to_rfc3339();
-            let result = conn.execute(
-                "INSERT INTO keystroke_logs (recorded_at, minute_count) VALUES (?1, ?2)",
-                params![recorded_at, count as i64],
-            );
-            if result.is_ok() {
-                let mut lock = minute_count.lock().unwrap();
-                *lock = lock.saturating_sub(count);
-                *today_db_count.lock().unwrap() += count;
-            }
+    let count = {
+        let mut lock = minute_count.lock().unwrap();
+        let count = *lock;
+        if count == 0 {
+            return;
         }
+        *lock = 0;
+        count
+    };
+
+    if let Ok(conn) = Connection::open(db_path) {
+        let recorded_at = Local::now().to_rfc3339();
+        let result = conn.execute(
+            "INSERT INTO keystroke_logs (recorded_at, minute_count) VALUES (?1, ?2)",
+            params![recorded_at, count as i64],
+        );
+        if result.is_ok() {
+            *today_db_count.lock().unwrap() += count;
+        } else {
+            *minute_count.lock().unwrap() += count;
+        }
+    } else {
+        *minute_count.lock().unwrap() += count;
     }
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,6 +8,13 @@ use tauri::{Emitter, Manager, State};
 
 struct DbPath(String);
 
+/// SQLite データベースを初期化する
+///
+/// `db_path` が存在しない場合はファイルを作成し、`keystroke_logs` テーブルを作成する。
+/// 既にテーブルが存在する場合は何もしない。
+///
+/// # Panics
+/// DB のオープンまたはテーブル作成に失敗した場合パニックする（起動時の必須処理のため）。
 fn init_db(db_path: &str) {
     let conn = Connection::open(db_path).expect("failed to open database");
     conn.execute_batch(
@@ -20,6 +27,16 @@ fn init_db(db_path: &str) {
     .expect("failed to initialize database schema");
 }
 
+/// 今日のキーストローク合計を SQLite から取得する（Tauri コマンド）
+///
+/// `recorded_at` が今日の日付で始まる行の `minute_count` を合計して返す。
+///
+/// # Returns
+/// 今日保存済みのキーストローク数の合計。取得失敗時は `0`。
+///
+/// # Note
+/// 現在のセッションで未保存の直近 1 分間分は含まない。
+/// フロントエンドはこの値にセッションカウントを加算して今日の合計を表示する。
 #[tauri::command]
 fn get_today_count(db_path: State<DbPath>) -> u64 {
     let Ok(conn) = Connection::open(&db_path.0) else {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -34,21 +34,22 @@ fn init_db(db_path: &str) {
 ///
 /// NOTE:
 ///   - count が 0 の場合は書き込みをスキップする
+///   - DB 書き込み成功後に保存した分だけ減算する（書き込み失敗時はカウントを保持）
+///   - 書き込み中に増加した分は saturating_sub により正しく保持される
 ///   - 1 分タイマーとアプリ終了時の両方から呼び出される
 fn flush_minute_count(minute_count: &Arc<Mutex<u64>>, db_path: &str) {
-    let count = {
-        let mut lock = minute_count.lock().unwrap();
-        let c = *lock;
-        *lock = 0;
-        c
-    };
+    let count = *minute_count.lock().unwrap();
     if count > 0 {
         if let Ok(conn) = Connection::open(db_path) {
             let recorded_at = Local::now().to_rfc3339();
-            let _ = conn.execute(
+            let result = conn.execute(
                 "INSERT INTO keystroke_logs (recorded_at, minute_count) VALUES (?1, ?2)",
                 params![recorded_at, count as i64],
             );
+            if result.is_ok() {
+                let mut lock = minute_count.lock().unwrap();
+                *lock = lock.saturating_sub(count);
+            }
         }
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -119,8 +119,7 @@ pub fn run() {
                 if let Err(e) = rdev::listen(move |event| {
                     if matches!(event.event_type, rdev::EventType::KeyPress(_)) {
                         *mc_rdev.lock().unwrap() += 1;
-                        let today_total =
-                            *tdc_rdev.lock().unwrap() + *mc_rdev.lock().unwrap();
+                        let today_total = *tdc_rdev.lock().unwrap() + *mc_rdev.lock().unwrap();
                         let _ = app_handle_rdev_emit.emit("keystroke_update", today_total);
                     }
                 }) {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -27,6 +27,32 @@ fn init_db(db_path: &str) {
     .expect("failed to initialize database schema");
 }
 
+/// `minute_count` の現在値を SQLite に保存し、0 にリセットする
+///
+/// @param minute_count 直近 1 分間のカウントを保持する Mutex
+/// @param db_path データベースファイルのパス
+///
+/// NOTE:
+///   - count が 0 の場合は書き込みをスキップする
+///   - 1 分タイマーとアプリ終了時の両方から呼び出される
+fn flush_minute_count(minute_count: &Arc<Mutex<u64>>, db_path: &str) {
+    let count = {
+        let mut lock = minute_count.lock().unwrap();
+        let c = *lock;
+        *lock = 0;
+        c
+    };
+    if count > 0 {
+        if let Ok(conn) = Connection::open(db_path) {
+            let recorded_at = Local::now().to_rfc3339();
+            let _ = conn.execute(
+                "INSERT INTO keystroke_logs (recorded_at, minute_count) VALUES (?1, ?2)",
+                params![recorded_at, count as i64],
+            );
+        }
+    }
+}
+
 /// 今日のキーストローク合計を SQLite から取得する（Tauri コマンド）
 ///
 /// `recorded_at` が今日の日付で始まる行の `minute_count` を合計して返す。
@@ -54,9 +80,15 @@ fn get_today_count(db_path: State<DbPath>) -> u64 {
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    tauri::Builder::default()
+    let session_count = Arc::new(Mutex::new(0u64));
+    let minute_count = Arc::new(Mutex::new(0u64));
+
+    let session_count_s = session_count.clone();
+    let minute_count_s = minute_count.clone();
+
+    let app = tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
-        .setup(|app| {
+        .setup(move |app| {
             let db_dir = app
                 .path()
                 .app_data_dir()
@@ -65,59 +97,48 @@ pub fn run() {
             let db_path = db_dir.join("keystroke.db").to_string_lossy().into_owned();
 
             init_db(&db_path);
-
-            let session_count = Arc::new(Mutex::new(0u64));
-            let minute_count = Arc::new(Mutex::new(0u64));
-
             app.manage(DbPath(db_path.clone()));
 
             // rdev keyboard listener
-            let session_count_rdev = session_count.clone();
-            let minute_count_rdev = minute_count.clone();
+            let sc_rdev = session_count_s.clone();
+            let mc_rdev = minute_count_s.clone();
             thread::spawn(move || {
                 rdev::listen(move |event| {
                     if matches!(event.event_type, rdev::EventType::KeyPress(_)) {
-                        *session_count_rdev.lock().unwrap() += 1;
-                        *minute_count_rdev.lock().unwrap() += 1;
+                        *sc_rdev.lock().unwrap() += 1;
+                        *mc_rdev.lock().unwrap() += 1;
                     }
                 })
                 .expect("failed to start keyboard listener");
             });
 
             // emit session count to frontend every second
-            let session_count_emit = session_count.clone();
+            let sc_emit = session_count_s.clone();
             let app_handle = app.handle().clone();
             thread::spawn(move || loop {
                 thread::sleep(Duration::from_secs(1));
-                let count = *session_count_emit.lock().unwrap();
+                let count = *sc_emit.lock().unwrap();
                 let _ = app_handle.emit("keystroke_update", count);
             });
 
             // persist minute count to SQLite every minute
-            let minute_count_save = minute_count.clone();
+            let mc_save = minute_count_s.clone();
             let db_path_save = db_path.clone();
             thread::spawn(move || loop {
                 thread::sleep(Duration::from_secs(60));
-                let count = {
-                    let mut lock = minute_count_save.lock().unwrap();
-                    let c = *lock;
-                    *lock = 0;
-                    c
-                };
-                if count > 0 {
-                    if let Ok(conn) = Connection::open(&db_path_save) {
-                        let recorded_at = Local::now().to_rfc3339();
-                        let _ = conn.execute(
-                            "INSERT INTO keystroke_logs (recorded_at, minute_count) VALUES (?1, ?2)",
-                            params![recorded_at, count as i64],
-                        );
-                    }
-                }
+                flush_minute_count(&mc_save, &db_path_save);
             });
 
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![get_today_count])
-        .run(tauri::generate_context!())
-        .expect("error while running tauri application");
+        .build(tauri::generate_context!())
+        .expect("error while building tauri application");
+
+    app.run(move |app_handle, event| {
+        if let tauri::RunEvent::Exit = event {
+            let db_path = app_handle.state::<DbPath>();
+            flush_minute_count(&minute_count, &db_path.0);
+        }
+    });
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -102,13 +102,15 @@ pub fn run() {
 
             // グローバルキーボードイベントのリスニング
             let mc_rdev = minute_count_s.clone();
+            let app_handle_rdev = app.handle().clone();
             thread::spawn(move || {
-                rdev::listen(move |event| {
+                if let Err(e) = rdev::listen(move |event| {
                     if matches!(event.event_type, rdev::EventType::KeyPress(_)) {
                         *mc_rdev.lock().unwrap() += 1;
                     }
-                })
-                .expect("failed to start keyboard listener");
+                }) {
+                    let _ = app_handle_rdev.emit("listener_error", format!("{e:?}"));
+                }
             });
 
             // today_total を 1 秒ごとにフロントエンドへ emit（日付変更も検知）

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -99,7 +99,7 @@ pub fn run() {
             init_db(&db_path);
             app.manage(DbPath(db_path.clone()));
 
-            // rdev keyboard listener
+            // グローバルキーボードイベントのリスニング
             let sc_rdev = session_count_s.clone();
             let mc_rdev = minute_count_s.clone();
             thread::spawn(move || {
@@ -112,7 +112,7 @@ pub fn run() {
                 .expect("failed to start keyboard listener");
             });
 
-            // emit session count to frontend every second
+            // セッションカウントを 1 秒ごとにフロントエンドへ emit
             let sc_emit = session_count_s.clone();
             let app_handle = app.handle().clone();
             thread::spawn(move || loop {
@@ -121,7 +121,7 @@ pub fn run() {
                 let _ = app_handle.emit("keystroke_update", count);
             });
 
-            // persist minute count to SQLite every minute
+            // 1 分ごとに SQLite へ保存
             let mc_save = minute_count_s.clone();
             let db_path_save = db_path.clone();
             thread::spawn(move || loop {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use chrono::Local;
 use rusqlite::{params, Connection};
-use tauri::{Emitter, Manager, State};
+use tauri::{Emitter, Manager};
 
 struct DbPath(String);
 
@@ -27,9 +27,10 @@ fn init_db(db_path: &str) {
     .expect("failed to initialize database schema");
 }
 
-/// `minute_count` の現在値を SQLite に保存し、0 にリセットする
+/// `minute_count` の現在値を SQLite に保存し、保存成功時に減算・`today_db_count` を加算する
 ///
-/// @param minute_count 直近 1 分間のカウントを保持する Mutex
+/// @param minute_count 直近の未保存キーストローク数
+/// @param today_db_count 今日の DB 保存済み合計（成功時にインクリメントされる）
 /// @param db_path データベースファイルのパス
 ///
 /// NOTE:
@@ -37,7 +38,11 @@ fn init_db(db_path: &str) {
 ///   - DB 書き込み成功後に保存した分だけ減算する（書き込み失敗時はカウントを保持）
 ///   - 書き込み中に増加した分は saturating_sub により正しく保持される
 ///   - 1 分タイマーとアプリ終了時の両方から呼び出される
-fn flush_minute_count(minute_count: &Arc<Mutex<u64>>, db_path: &str) {
+fn flush_minute_count(
+    minute_count: &Arc<Mutex<u64>>,
+    today_db_count: &Arc<Mutex<u64>>,
+    db_path: &str,
+) {
     let count = *minute_count.lock().unwrap();
     if count > 0 {
         if let Ok(conn) = Connection::open(db_path) {
@@ -49,24 +54,18 @@ fn flush_minute_count(minute_count: &Arc<Mutex<u64>>, db_path: &str) {
             if result.is_ok() {
                 let mut lock = minute_count.lock().unwrap();
                 *lock = lock.saturating_sub(count);
+                *today_db_count.lock().unwrap() += count;
             }
         }
     }
 }
 
-/// 今日のキーストローク合計を SQLite から取得する（Tauri コマンド）
-///
-/// `recorded_at` が今日の日付で始まる行の `minute_count` を合計して返す。
+/// 今日の日付で保存された `keystroke_logs` の合計を SQLite から取得する
 ///
 /// # Returns
 /// 今日保存済みのキーストローク数の合計。取得失敗時は `0`。
-///
-/// # Note
-/// 現在のセッションで未保存の直近 1 分間分は含まない。
-/// フロントエンドはこの値にセッションカウントを加算して今日の合計を表示する。
-#[tauri::command]
-fn get_today_count(db_path: State<DbPath>) -> u64 {
-    let Ok(conn) = Connection::open(&db_path.0) else {
+fn query_today_db_count(db_path: &str) -> u64 {
+    let Ok(conn) = Connection::open(db_path) else {
         return 0;
     };
     let today = Local::now().format("%Y-%m-%d").to_string();
@@ -81,11 +80,11 @@ fn get_today_count(db_path: State<DbPath>) -> u64 {
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    let session_count = Arc::new(Mutex::new(0u64));
     let minute_count = Arc::new(Mutex::new(0u64));
+    let today_db_count = Arc::new(Mutex::new(0u64));
 
-    let session_count_s = session_count.clone();
     let minute_count_s = minute_count.clone();
+    let today_db_count_s = today_db_count.clone();
 
     let app = tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
@@ -98,48 +97,58 @@ pub fn run() {
             let db_path = db_dir.join("keystroke.db").to_string_lossy().into_owned();
 
             init_db(&db_path);
+            *today_db_count_s.lock().unwrap() = query_today_db_count(&db_path);
             app.manage(DbPath(db_path.clone()));
 
             // グローバルキーボードイベントのリスニング
-            let sc_rdev = session_count_s.clone();
             let mc_rdev = minute_count_s.clone();
             thread::spawn(move || {
                 rdev::listen(move |event| {
                     if matches!(event.event_type, rdev::EventType::KeyPress(_)) {
-                        *sc_rdev.lock().unwrap() += 1;
                         *mc_rdev.lock().unwrap() += 1;
                     }
                 })
                 .expect("failed to start keyboard listener");
             });
 
-            // セッションカウントを 1 秒ごとにフロントエンドへ emit
-            let sc_emit = session_count_s.clone();
+            // today_total を 1 秒ごとにフロントエンドへ emit（日付変更も検知）
+            let mc_emit = minute_count_s.clone();
+            let tdc_emit = today_db_count_s.clone();
             let app_handle = app.handle().clone();
-            thread::spawn(move || loop {
-                thread::sleep(Duration::from_secs(1));
-                let count = *sc_emit.lock().unwrap();
-                let _ = app_handle.emit("keystroke_update", count);
+            thread::spawn(move || {
+                let mut last_date = Local::now().format("%Y-%m-%d").to_string();
+                loop {
+                    thread::sleep(Duration::from_secs(1));
+                    let current_date = Local::now().format("%Y-%m-%d").to_string();
+                    if current_date != last_date {
+                        // 日付が変わったら今日の DB 合計をリセット
+                        *tdc_emit.lock().unwrap() = 0;
+                        last_date = current_date;
+                    }
+                    let today_total = *tdc_emit.lock().unwrap() + *mc_emit.lock().unwrap();
+                    let _ = app_handle.emit("keystroke_update", today_total);
+                }
             });
 
             // 1 分ごとに SQLite へ保存
             let mc_save = minute_count_s.clone();
+            let tdc_save = today_db_count_s.clone();
             let db_path_save = db_path.clone();
             thread::spawn(move || loop {
                 thread::sleep(Duration::from_secs(60));
-                flush_minute_count(&mc_save, &db_path_save);
+                flush_minute_count(&mc_save, &tdc_save, &db_path_save);
             });
 
             Ok(())
         })
-        .invoke_handler(tauri::generate_handler![get_today_count])
+        .invoke_handler(tauri::generate_handler![])
         .build(tauri::generate_context!())
         .expect("error while building tauri application");
 
     app.run(move |app_handle, event| {
         if let tauri::RunEvent::Exit = event {
             let db_path = app_handle.state::<DbPath>();
-            flush_minute_count(&minute_count, &db_path.0);
+            flush_minute_count(&minute_count, &today_db_count, &db_path.0);
         }
     });
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -29,15 +29,16 @@ fn init_db(db_path: &str) {
 
 /// `minute_count` の現在値を SQLite に保存し、保存成功時に減算・`today_db_count` を加算する
 ///
-/// @param minute_count 直近の未保存キーストローク数
-/// @param today_db_count 今日の DB 保存済み合計（成功時にインクリメントされる）
-/// @param db_path データベースファイルのパス
+/// # Parameters
+/// * `minute_count` - 直近の未保存キーストローク数
+/// * `today_db_count` - 今日の DB 保存済み合計（書き込み成功時にインクリメントされる）
+/// * `db_path` - データベースファイルのパス
 ///
-/// NOTE:
-///   - count が 0 の場合は書き込みをスキップする
-///   - DB 書き込み成功後に保存した分だけ減算する（書き込み失敗時はカウントを保持）
-///   - 書き込み中に増加した分は saturating_sub により正しく保持される
-///   - 1 分タイマーとアプリ終了時の両方から呼び出される
+/// # Behavior
+/// * `minute_count` が 0 の場合は書き込みをスキップする
+/// * DB 書き込み成功後に保存した分だけ減算する（失敗時はカウントを保持）
+/// * 書き込み中に増加した分は `saturating_sub` により正しく保持される
+/// * 1 分タイマーとアプリ終了時の両方から呼び出される
 fn flush_minute_count(
     minute_count: &Arc<Mutex<u64>>,
     today_db_count: &Arc<Mutex<u64>>,

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
-import { invoke } from '@tauri-apps/api/core';
-import { listen } from '@tauri-apps/api/event';
 import { computed, onMounted, onUnmounted, ref } from 'vue';
+import { fetchTodayCount, subscribeKeystrokeUpdate } from './lib/keystroke';
 
 const todayCountAtStart = ref(0);
 const sessionCount = ref(0);
@@ -11,10 +10,9 @@ const todayTotal = computed(() => todayCountAtStart.value + sessionCount.value);
 let unlisten: (() => void) | null = null;
 
 onMounted(async () => {
-  todayCountAtStart.value = await invoke<number>('get_today_count');
-
-  unlisten = await listen<number>('keystroke_update', (event) => {
-    sessionCount.value = event.payload;
+  todayCountAtStart.value = await fetchTodayCount();
+  unlisten = await subscribeKeystrokeUpdate((count) => {
+    sessionCount.value = count;
   });
 });
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -2,7 +2,7 @@
 import { onMounted, onUnmounted, ref } from 'vue';
 import { subscribeKeystrokeUpdate, subscribeListenerError } from './lib/keystroke';
 
-const todayTotal = ref(0);
+const todayTotal = ref<number | null>(null);
 const listenerError = ref<string | null>(null);
 
 const unlisteners: Array<() => void> = [];
@@ -29,9 +29,12 @@ onUnmounted(() => {
       <p class="error-label">キーボード監視を開始できませんでした</p>
       <p class="error-detail">{{ listenerError }}</p>
     </template>
-    <template v-else>
+    <template v-else-if="todayTotal !== null">
       <p class="label">今日</p>
       <p class="count">{{ todayTotal.toLocaleString() }}</p>
+    </template>
+    <template v-else>
+      <p class="loading">読み込み中</p>
     </template>
   </main>
 </template>
@@ -88,5 +91,11 @@ onUnmounted(() => {
   opacity: 0.6;
   margin: 0;
   font-family: monospace;
+}
+
+.loading {
+  font-size: 1rem;
+  opacity: 0.4;
+  margin: 0;
 }
 </style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,134 +1,43 @@
 <script setup lang="ts">
 import { invoke } from '@tauri-apps/api/core';
-import { ref } from 'vue';
+import { listen } from '@tauri-apps/api/event';
+import { computed, onMounted, onUnmounted, ref } from 'vue';
 
-const greetMsg = ref('');
-const name = ref('');
+const todayCountAtStart = ref(0);
+const sessionCount = ref(0);
 
-async function greet() {
-  // Learn more about Tauri commands at https://tauri.app/develop/calling-rust/
-  greetMsg.value = await invoke('greet', { name: name.value });
-}
+const todayTotal = computed(() => todayCountAtStart.value + sessionCount.value);
+
+let unlisten: (() => void) | null = null;
+
+onMounted(async () => {
+  todayCountAtStart.value = await invoke<number>('get_today_count');
+
+  unlisten = await listen<number>('keystroke_update', (event) => {
+    sessionCount.value = event.payload;
+  });
+});
+
+onUnmounted(() => {
+  unlisten?.();
+});
 </script>
 
 <template>
   <main class="container">
-    <h1>Welcome to Tauri + Vue</h1>
-
-    <div class="row">
-      <a href="https://vite.dev" target="_blank">
-        <img src="/vite.svg" class="logo vite" alt="Vite logo" />
-      </a>
-      <a href="https://tauri.app" target="_blank">
-        <img src="/tauri.svg" class="logo tauri" alt="Tauri logo" />
-      </a>
-      <a href="https://vuejs.org/" target="_blank">
-        <img src="./assets/vue.svg" class="logo vue" alt="Vue logo" />
-      </a>
-    </div>
-    <p>Click on the Tauri, Vite, and Vue logos to learn more.</p>
-
-    <form class="row" @submit.prevent="greet">
-      <input id="greet-input" v-model="name" placeholder="Enter a name..." />
-      <button type="submit">Greet</button>
-    </form>
-    <p>{{ greetMsg }}</p>
+    <p class="label">今日</p>
+    <p class="count">{{ todayTotal.toLocaleString() }}</p>
   </main>
 </template>
 
-<style scoped>
-.logo.vite:hover {
-  filter: drop-shadow(0 0 2em #747bff);
-}
-
-.logo.vue:hover {
-  filter: drop-shadow(0 0 2em #249b73);
-}
-</style>
 <style>
 :root {
   font-family: Inter, Avenir, Helvetica, Arial, sans-serif;
-  font-size: 16px;
-  line-height: 24px;
-  font-weight: 400;
-  color: #0f0f0f;
-  background-color: #f6f6f6;
   font-synthesis: none;
   text-rendering: optimizelegibility;
   -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  text-size-adjust: 100%;
-}
-
-.container {
-  margin: 0;
-  padding-top: 10vh;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  text-align: center;
-}
-
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: 0.75s;
-}
-
-.logo.tauri:hover {
-  filter: drop-shadow(0 0 2em #24c8db);
-}
-
-.row {
-  display: flex;
-  justify-content: center;
-}
-
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-
-a:hover {
-  color: #535bf2;
-}
-
-h1 {
-  text-align: center;
-}
-
-input,
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
   color: #0f0f0f;
-  background-color: #fff;
-  transition: border-color 0.25s;
-  box-shadow: 0 2px 2px rgb(0 0 0 / 20%);
-  outline: none;
-}
-
-button {
-  cursor: pointer;
-}
-
-button:hover {
-  border-color: #396cd8;
-}
-
-button:active {
-  border-color: #396cd8;
-  background-color: #e8e8e8;
-}
-
-#greet-input {
-  margin-right: 5px;
+  background-color: #f6f6f6;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -136,19 +45,29 @@ button:active {
     color: #f6f6f6;
     background-color: #2f2f2f;
   }
+}
+</style>
 
-  a:hover {
-    color: #24c8db;
-  }
+<style scoped>
+.container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100vh;
+  gap: 8px;
+}
 
-  input,
-  button {
-    color: #fff;
-    background-color: #0f0f0f98;
-  }
+.label {
+  font-size: 1rem;
+  opacity: 0.6;
+  margin: 0;
+}
 
-  button:active {
-    background-color: #0f0f0f69;
-  }
+.count {
+  font-size: 4rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  margin: 0;
 }
 </style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,18 +1,14 @@
 <script setup lang="ts">
-import { computed, onMounted, onUnmounted, ref } from 'vue';
-import { fetchTodayCount, subscribeKeystrokeUpdate } from './lib/keystroke';
+import { onMounted, onUnmounted, ref } from 'vue';
+import { subscribeKeystrokeUpdate } from './lib/keystroke';
 
-const todayCountAtStart = ref(0);
-const sessionCount = ref(0);
-
-const todayTotal = computed(() => todayCountAtStart.value + sessionCount.value);
+const todayTotal = ref(0);
 
 let unlisten: (() => void) | null = null;
 
 onMounted(async () => {
-  todayCountAtStart.value = await fetchTodayCount();
-  unlisten = await subscribeKeystrokeUpdate((count) => {
-    sessionCount.value = count;
+  unlisten = await subscribeKeystrokeUpdate((total) => {
+    todayTotal.value = total;
   });
 });
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,26 +1,38 @@
 <script setup lang="ts">
 import { onMounted, onUnmounted, ref } from 'vue';
-import { subscribeKeystrokeUpdate } from './lib/keystroke';
+import { subscribeKeystrokeUpdate, subscribeListenerError } from './lib/keystroke';
 
 const todayTotal = ref(0);
+const listenerError = ref<string | null>(null);
 
-let unlisten: (() => void) | null = null;
+const unlisteners: Array<() => void> = [];
 
 onMounted(async () => {
-  unlisten = await subscribeKeystrokeUpdate((total) => {
-    todayTotal.value = total;
-  });
+  unlisteners.push(
+    await subscribeKeystrokeUpdate((total) => {
+      todayTotal.value = total;
+    }),
+    await subscribeListenerError((message) => {
+      listenerError.value = message;
+    }),
+  );
 });
 
 onUnmounted(() => {
-  unlisten?.();
+  unlisteners.forEach((fn) => fn());
 });
 </script>
 
 <template>
   <main class="container">
-    <p class="label">今日</p>
-    <p class="count">{{ todayTotal.toLocaleString() }}</p>
+    <template v-if="listenerError">
+      <p class="error-label">キーボード監視を開始できませんでした</p>
+      <p class="error-detail">{{ listenerError }}</p>
+    </template>
+    <template v-else>
+      <p class="label">今日</p>
+      <p class="count">{{ todayTotal.toLocaleString() }}</p>
+    </template>
   </main>
 </template>
 
@@ -63,5 +75,18 @@ onUnmounted(() => {
   font-weight: 700;
   letter-spacing: -0.02em;
   margin: 0;
+}
+
+.error-label {
+  font-size: 1rem;
+  color: #e53e3e;
+  margin: 0;
+}
+
+.error-detail {
+  font-size: 0.75rem;
+  opacity: 0.6;
+  margin: 0;
+  font-family: monospace;
 }
 </style>

--- a/src/lib/keystroke.ts
+++ b/src/lib/keystroke.ts
@@ -13,3 +13,16 @@ import { listen } from '@tauri-apps/api/event';
 export const subscribeKeystrokeUpdate = (
   callback: (todayTotal: number) => void,
 ): Promise<() => void> => listen<number>('keystroke_update', (event) => callback(event.payload));
+
+/**
+ * @function キーボードリスナーのエラーイベントを購読する
+ *
+ * @param callback エラーメッセージを受け取るコールバック
+ * @returns unlisten 関数（コンポーネントアンマウント時に呼び出すこと）
+ *
+ * NOTE:
+ *   - rdev のグローバルキーボード監視が開始できなかった場合に emit される
+ *   - 一度 emit されたあとはキーカウントが更新されなくなる
+ */
+export const subscribeListenerError = (callback: (message: string) => void): Promise<() => void> =>
+  listen<string>('listener_error', (event) => callback(event.payload));

--- a/src/lib/keystroke.ts
+++ b/src/lib/keystroke.ts
@@ -1,27 +1,15 @@
-import { invoke } from '@tauri-apps/api/core';
 import { listen } from '@tauri-apps/api/event';
-
-/**
- * @function 今日の保存済みキーストローク合計を取得する
- *
- * @returns 今日の SQLite に保存されたキーストローク数の合計
- *
- * NOTE:
- *   - 現在のセッション分（未保存の直近 1 分間）は含まない
- *   - DB 取得失敗時は Rust 側が 0 を返す
- */
-export const fetchTodayCount = (): Promise<number> => invoke<number>('get_today_count');
 
 /**
  * @function キーストローク更新イベントを購読する
  *
- * @param callback セッション開始からの累計キー数を受け取るコールバック
+ * @param callback 今日の合計キー数（DB 保存済み + 未保存分）を受け取るコールバック
  * @returns unlisten 関数（コンポーネントアンマウント時に呼び出すこと）
  *
  * NOTE:
  *   - イベントは Rust 側から 1 秒ごとに emit される
- *   - payload はセッション開始時を 0 とした累計カウント
+ *   - payload は今日の合計カウント（日付変更時に自動リセット）
  */
 export const subscribeKeystrokeUpdate = (
-  callback: (sessionCount: number) => void,
+  callback: (todayTotal: number) => void,
 ): Promise<() => void> => listen<number>('keystroke_update', (event) => callback(event.payload));

--- a/src/lib/keystroke.ts
+++ b/src/lib/keystroke.ts
@@ -1,0 +1,27 @@
+import { invoke } from '@tauri-apps/api/core';
+import { listen } from '@tauri-apps/api/event';
+
+/**
+ * @function 今日の保存済みキーストローク合計を取得する
+ *
+ * @returns 今日の SQLite に保存されたキーストローク数の合計
+ *
+ * NOTE:
+ *   - 現在のセッション分（未保存の直近 1 分間）は含まない
+ *   - DB 取得失敗時は Rust 側が 0 を返す
+ */
+export const fetchTodayCount = (): Promise<number> => invoke<number>('get_today_count');
+
+/**
+ * @function キーストローク更新イベントを購読する
+ *
+ * @param callback セッション開始からの累計キー数を受け取るコールバック
+ * @returns unlisten 関数（コンポーネントアンマウント時に呼び出すこと）
+ *
+ * NOTE:
+ *   - イベントは Rust 側から 1 秒ごとに emit される
+ *   - payload はセッション開始時を 0 とした累計カウント
+ */
+export const subscribeKeystrokeUpdate = (
+  callback: (sessionCount: number) => void,
+): Promise<() => void> => listen<number>('keystroke_update', (event) => callback(event.payload));


### PR DESCRIPTION
close #

### 背景

typemeter のコア機能として、キーストローク数の計測・保存・表示を実装した。

### 概要

OS レベルのグローバルキーボード監視により、アプリがバックグラウンドでも全キー入力を計測し、SQLite に定期保存する。UI はリアルタイムで今日の合計を表示する。

### 変更内容

- `rdev` によるグローバルキーボードイベントの監視（ウィンドウフォーカス不要）
- `rusqlite` による SQLite 保存（1 分ごと、および終了時に残余分を確実に保存）
- Tauri イベント経由でキー押下ごとにフロントエンドへカウントを emit
- フロントエンド: 「今日の合計（DB 保存済み + 現セッション）」をリアルタイム表示
- `src/lib/keystroke.ts` に Tauri IPC ラッパー関数を分離
- Rust 関数に Rustdoc コメントを追加、インラインコメントを日本語に統一

### チェック項目

- [ ] アプリがバックグラウンドのときもカウントが増えること
- [ ] UI がキー押下時に即座に更新されること
- [ ] 1 分後に `%APPDATA%\com.taish.typemeter\keystroke.db` に行が追加されること
- [ ] アプリを閉じたとき、残余の minute_count が DB に保存されること

### 備考

- SQLite は `tauri-plugin-sql`（フロントエンド主導）ではなく `rusqlite` を直接使用。バックグラウンドスレッドからの書き込みが主体のため。
- `RunEvent::Exit` で終了を検知し、`app_handle.state::<DbPath>()` で管理済みの DB パスを参照して保存。