### PR TITLE
fix(lib): macOS Tahoe でのクラッシュとキーストローク未検知を修正

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2279,9 +2279,17 @@ checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.11.1",
  "block2",
+ "libc",
  "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
  "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-text",
+ "objc2-core-video",
  "objc2-foundation",
+ "objc2-quartz-core",
 ]
 
 [[package]]
@@ -2301,6 +2309,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
 dependencies = [
+ "bitflags 2.11.1",
  "objc2",
  "objc2-foundation",
 ]
@@ -2359,6 +2368,19 @@ dependencies = [
  "objc2",
  "objc2-core-foundation",
  "objc2-core-graphics",
+]
+
+[[package]]
+name = "objc2-core-video"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-io-surface",
 ]
 
 [[package]]
@@ -4173,7 +4195,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 name = "typemeter"
 version = "0.1.0"
 dependencies = [
+ "block2",
  "chrono",
+ "objc2-app-kit",
  "rdev",
  "rusqlite",
  "serde",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2279,17 +2279,9 @@ checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.11.1",
  "block2",
- "libc",
  "objc2",
- "objc2-cloud-kit",
- "objc2-core-data",
  "objc2-core-foundation",
- "objc2-core-graphics",
- "objc2-core-image",
- "objc2-core-text",
- "objc2-core-video",
  "objc2-foundation",
- "objc2-quartz-core",
 ]
 
 [[package]]
@@ -2309,7 +2301,6 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
 dependencies = [
- "bitflags 2.11.1",
  "objc2",
  "objc2-foundation",
 ]
@@ -2368,19 +2359,6 @@ dependencies = [
  "objc2",
  "objc2-core-foundation",
  "objc2-core-graphics",
-]
-
-[[package]]
-name = "objc2-core-video"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
-dependencies = [
- "bitflags 2.11.1",
- "objc2",
- "objc2-core-foundation",
- "objc2-core-graphics",
- "objc2-io-surface",
 ]
 
 [[package]]
@@ -4195,9 +4173,7 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 name = "typemeter"
 version = "0.1.0"
 dependencies = [
- "block2",
  "chrono",
- "objc2-app-kit",
  "rdev",
  "rusqlite",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -28,7 +28,4 @@ chrono = "0.4"
 [target.'cfg(not(target_os = "macos"))'.dependencies]
 rdev = "0.5"
 
-[target.'cfg(target_os = "macos")'.dependencies]
-objc2-app-kit = { version = "0.3", features = ["NSEvent"] }
-block2 = "0.6"
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -22,7 +22,13 @@ tauri = { version = "2", features = [] }
 tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-rdev = "0.5"
 rusqlite = { version = "0.32", features = ["bundled"] }
 chrono = "0.4"
+
+[target.'cfg(not(target_os = "macos"))'.dependencies]
+rdev = "0.5"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2-app-kit = { version = "0.3", features = ["NSEvent"] }
+block2 = "0.6"
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -260,12 +260,21 @@ pub fn run() {
                 });
                 let data_ptr = Box::into_raw(data) as *mut c_void;
 
+                // セッションイベントをアプリ側に注釈付きで届けるタップポイント
+                const KCG_ANNOTATED_SESSION_EVENT_TAP: u32 = 2;
+                // イベントパイプラインの末尾に追加（リッスン専用タップに適切）
+                const KCG_TAIL_APPEND_EVENT_TAP: u32 = 1;
+                // イベントを変更しないリッスン専用モード（デフォルト = 0 はイベント変更可）
+                const KCG_EVENT_TAP_OPTION_LISTEN_ONLY: u32 = 1;
+                // kCGEventKeyDown (= 10) に対応するビットマスク
+                const KCG_EVENT_KEY_DOWN_MASK: u64 = 1 << 10;
+
                 let tap = unsafe {
                     CGEventTapCreate(
-                        2,       // kCGAnnotatedSessionEventTap
-                        1,       // kCGTailAppendEventTap
-                        1,       // kCGEventTapOptionListenOnly
-                        1 << 10, // kCGEventKeyDown mask
+                        KCG_ANNOTATED_SESSION_EVENT_TAP,
+                        KCG_TAIL_APPEND_EVENT_TAP,
+                        KCG_EVENT_TAP_OPTION_LISTEN_ONLY,
+                        KCG_EVENT_KEY_DOWN_MASK,
                         tap_callback,
                         data_ptr,
                     )

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -203,8 +203,7 @@ pub fn run() {
                     if let Err(e) = rdev::listen(move |event| {
                         if matches!(event.event_type, rdev::EventType::KeyPress(_)) {
                             *mc_rdev.lock().unwrap() += 1;
-                            let today_total =
-                                *tdc_rdev.lock().unwrap() + *mc_rdev.lock().unwrap();
+                            let today_total = *tdc_rdev.lock().unwrap() + *mc_rdev.lock().unwrap();
                             let _ = app_handle_rdev_emit.emit("keystroke_update", today_total);
                         }
                     }) {
@@ -263,9 +262,9 @@ pub fn run() {
 
                 let tap = unsafe {
                     CGEventTapCreate(
-                        2, // kCGAnnotatedSessionEventTap
-                        1, // kCGTailAppendEventTap
-                        1, // kCGEventTapOptionListenOnly
+                        2,       // kCGAnnotatedSessionEventTap
+                        1,       // kCGTailAppendEventTap
+                        1,       // kCGEventTapOptionListenOnly
                         1 << 10, // kCGEventKeyDown mask
                         tap_callback,
                         data_ptr,
@@ -282,8 +281,7 @@ pub fn run() {
                 let tap_addr = tap as usize;
                 thread::spawn(move || {
                     let tap = tap_addr as *mut c_void;
-                    let source =
-                        unsafe { CFMachPortCreateRunLoopSource(std::ptr::null(), tap, 0) };
+                    let source = unsafe { CFMachPortCreateRunLoopSource(std::ptr::null(), tap, 0) };
                     let run_loop = unsafe { CFRunLoopGetCurrent() };
                     unsafe {
                         CFRunLoopAddSource(run_loop, source, kCFRunLoopCommonModes);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -298,7 +298,10 @@ pub fn run() {
                     let run_loop = unsafe { CFRunLoopGetCurrent() };
                     unsafe {
                         CFRunLoopAddSource(run_loop, source, kCFRunLoopCommonModes);
+                        // source はランループが retain 済みのため自分側の参照を解放する
                         CFRelease(source as *const c_void);
+                        // source が tap を retain 済みのため自分側の参照を解放する
+                        CFRelease(tap as *const c_void);
                         CFRunLoopRun();
                     }
                 });

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -309,7 +309,6 @@ pub fn run() {
                 event: tauri::WindowEvent::CloseRequested { .. },
                 ..
             } => {
-                // exit(0) が RunEvent::Exit を発火させるため、フラッシュは Exit 側に一本化する
                 app_handle.exit(0);
             }
             tauri::RunEvent::Exit => {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+use std::ffi::c_void;
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
@@ -6,7 +7,65 @@ use chrono::Local;
 use rusqlite::{params, Connection};
 use tauri::{Emitter, Manager};
 
+// 他アプリへのキー入力監視に必要な Input Monitoring 権限を要求する
+#[cfg(target_os = "macos")]
+#[link(name = "CoreGraphics", kind = "framework")]
+extern "C" {
+    fn CGRequestListenEventAccess() -> bool;
+    fn CGEventTapCreate(
+        tap: u32,
+        place: u32,
+        options: u32,
+        events_of_interest: u64,
+        callback: unsafe extern "C" fn(*mut c_void, u32, *mut c_void, *mut c_void) -> *mut c_void,
+        user_info: *mut c_void,
+    ) -> *mut c_void;
+}
+
+#[cfg(target_os = "macos")]
+#[link(name = "CoreFoundation", kind = "framework")]
+extern "C" {
+    fn CFMachPortCreateRunLoopSource(
+        allocator: *const c_void,
+        port: *mut c_void,
+        order: isize,
+    ) -> *mut c_void;
+    fn CFRunLoopAddSource(rl: *mut c_void, source: *mut c_void, mode: *const c_void);
+    fn CFRunLoopGetCurrent() -> *mut c_void;
+    fn CFRunLoopRun();
+    fn CFRelease(cf: *const c_void);
+    static kCFRunLoopCommonModes: *const c_void;
+}
+
 struct DbPath(String);
+
+#[cfg(target_os = "macos")]
+struct TapUserData {
+    minute_count: Arc<Mutex<u64>>,
+    today_db_count: Arc<Mutex<u64>>,
+    app_handle: tauri::AppHandle,
+}
+
+/// CGEventTap コールバック
+///
+/// kCGEventKeyDown のみカウントする。TSM API（TSMGetInputSourceProperty 等）は
+/// 呼び出さないため、macOS Tahoe (26) での dispatch_assert_queue クラッシュは発生しない。
+#[cfg(target_os = "macos")]
+unsafe extern "C" fn tap_callback(
+    _proxy: *mut c_void,
+    event_type: u32,
+    event: *mut c_void,
+    user_info: *mut c_void,
+) -> *mut c_void {
+    const CG_EVENT_KEY_DOWN: u32 = 10;
+    if event_type == CG_EVENT_KEY_DOWN {
+        let data = &*(user_info as *const TapUserData);
+        *data.minute_count.lock().unwrap() += 1;
+        let today_total = *data.today_db_count.lock().unwrap() + *data.minute_count.lock().unwrap();
+        let _ = data.app_handle.emit("keystroke_update", today_total);
+    }
+    event
+}
 
 /// SQLite データベースを初期化する
 ///
@@ -96,6 +155,12 @@ pub fn run() {
     let minute_count_s = minute_count.clone();
     let today_db_count_s = today_db_count.clone();
 
+    // macOS: CGEventTap はイベントループ起動後（RunEvent::Ready）で登録する
+    #[cfg(target_os = "macos")]
+    let minute_count_ready = minute_count.clone();
+    #[cfg(target_os = "macos")]
+    let today_db_count_ready = today_db_count.clone();
+
     let app = tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .setup(move |app| {
@@ -124,45 +189,9 @@ pub fn run() {
             app.manage(DbPath(db_path.clone()));
 
             // グローバルキーボードイベントのリスニング（キー押下時に即 emit）
-            //
-            // macOS: rdev は CGEventTap コールバック内で TSMGetInputSourceProperty を
-            //        呼び出すが、macOS Tahoe (26) でこの API がメインキュー必須になり
-            //        dispatch_assert_queue でクラッシュする。代わりに NSEvent の
-            //        グローバルモニターを使う。
-            // その他: rdev をそのまま使用する。
-            #[cfg(target_os = "macos")]
-            {
-                use block2::RcBlock;
-                use objc2_app_kit::{NSEvent, NSEventMask};
-                use std::ptr::NonNull;
-
-                let mc_ns = minute_count_s.clone();
-                let tdc_ns = today_db_count_s.clone();
-                let app_handle_emit = app.handle().clone();
-                let app_handle_err = app.handle().clone();
-
-                let handler = RcBlock::new(move |_event: NonNull<NSEvent>| {
-                    *mc_ns.lock().unwrap() += 1;
-                    let today_total = *tdc_ns.lock().unwrap() + *mc_ns.lock().unwrap();
-                    let _ = app_handle_emit.emit("keystroke_update", today_total);
-                });
-
-                match NSEvent::addGlobalMonitorForEventsMatchingMask_handler(
-                    NSEventMask::KeyDown,
-                    &handler,
-                ) {
-                    Some(monitor) => {
-                        // drop するとイベント監視が解除されるため意図的にリーク
-                        std::mem::forget(monitor);
-                    }
-                    None => {
-                        let _ = app_handle_err
-                            .emit("listener_error", "入力監視の開始に失敗しました");
-                    }
-                }
-                // handler は NSEvent が retain 済みのため drop しても監視は継続する
-            }
-
+            // macOS: CGEventTap を直接使用（TSM API を呼ばない最小限のコールバック）
+            //        RunEvent::Ready でイベントループ起動後に登録する
+            // その他: rdev をそのまま使用する
             #[cfg(not(target_os = "macos"))]
             {
                 let mc_rdev = minute_count_s.clone();
@@ -218,9 +247,55 @@ pub fn run() {
         .expect("error while building tauri application");
 
     app.run(move |app_handle, event| {
-        if let tauri::RunEvent::Exit = event {
-            let db_path = app_handle.state::<DbPath>();
-            flush_minute_count(&minute_count, &today_db_count, &db_path.0);
+        match event {
+            #[cfg(target_os = "macos")]
+            tauri::RunEvent::Ready => {
+                // Input Monitoring 権限がなければシステム設定への誘導ダイアログを表示する
+                unsafe { CGRequestListenEventAccess() };
+
+                let data = Box::new(TapUserData {
+                    minute_count: minute_count_ready.clone(),
+                    today_db_count: today_db_count_ready.clone(),
+                    app_handle: app_handle.clone(),
+                });
+                let data_ptr = Box::into_raw(data) as *mut c_void;
+
+                let tap = unsafe {
+                    CGEventTapCreate(
+                        2, // kCGAnnotatedSessionEventTap
+                        1, // kCGTailAppendEventTap
+                        1, // kCGEventTapOptionListenOnly
+                        1 << 10, // kCGEventKeyDown mask
+                        tap_callback,
+                        data_ptr,
+                    )
+                };
+
+                if tap.is_null() {
+                    let _ = app_handle.emit("listener_error", "入力監視の開始に失敗しました");
+                    unsafe { drop(Box::from_raw(data_ptr as *mut TapUserData)) };
+                    return;
+                }
+
+                // *mut c_void は Send でないため usize で渡す（アドレス値のみ保持）
+                let tap_addr = tap as usize;
+                thread::spawn(move || {
+                    let tap = tap_addr as *mut c_void;
+                    let source =
+                        unsafe { CFMachPortCreateRunLoopSource(std::ptr::null(), tap, 0) };
+                    let run_loop = unsafe { CFRunLoopGetCurrent() };
+                    unsafe {
+                        CFRunLoopAddSource(run_loop, source, kCFRunLoopCommonModes);
+                        CFRelease(source as *const c_void);
+                        CFRunLoopRun();
+                    }
+                });
+            }
+            tauri::RunEvent::Exit => {
+                let db_path = app_handle.state::<DbPath>();
+                flush_minute_count(&minute_count, &today_db_count, &db_path.0);
+            }
+            _ => {}
         }
     });
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -291,6 +291,16 @@ pub fn run() {
                     }
                 });
             }
+            // macOS では赤×でウィンドウを閉じてもプロセスが残り Exit が来ないため、
+            // CloseRequested でフラッシュしてから明示的に終了する
+            tauri::RunEvent::WindowEvent {
+                event: tauri::WindowEvent::CloseRequested { .. },
+                ..
+            } => {
+                let db_path = app_handle.state::<DbPath>();
+                flush_minute_count(&minute_count, &today_db_count, &db_path.0);
+                app_handle.exit(0);
+            }
             tauri::RunEvent::Exit => {
                 let db_path = app_handle.state::<DbPath>();
                 flush_minute_count(&minute_count, &today_db_count, &db_path.0);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -124,21 +124,64 @@ pub fn run() {
             app.manage(DbPath(db_path.clone()));
 
             // グローバルキーボードイベントのリスニング（キー押下時に即 emit）
-            let mc_rdev = minute_count_s.clone();
-            let tdc_rdev = today_db_count_s.clone();
-            let app_handle_rdev_emit = app.handle().clone();
-            let app_handle_rdev_err = app.handle().clone();
-            thread::spawn(move || {
-                if let Err(e) = rdev::listen(move |event| {
-                    if matches!(event.event_type, rdev::EventType::KeyPress(_)) {
-                        *mc_rdev.lock().unwrap() += 1;
-                        let today_total = *tdc_rdev.lock().unwrap() + *mc_rdev.lock().unwrap();
-                        let _ = app_handle_rdev_emit.emit("keystroke_update", today_total);
+            //
+            // macOS: rdev は CGEventTap コールバック内で TSMGetInputSourceProperty を
+            //        呼び出すが、macOS Tahoe (26) でこの API がメインキュー必須になり
+            //        dispatch_assert_queue でクラッシュする。代わりに NSEvent の
+            //        グローバルモニターを使う。
+            // その他: rdev をそのまま使用する。
+            #[cfg(target_os = "macos")]
+            {
+                use block2::RcBlock;
+                use objc2_app_kit::{NSEvent, NSEventMask};
+                use std::ptr::NonNull;
+
+                let mc_ns = minute_count_s.clone();
+                let tdc_ns = today_db_count_s.clone();
+                let app_handle_emit = app.handle().clone();
+                let app_handle_err = app.handle().clone();
+
+                let handler = RcBlock::new(move |_event: NonNull<NSEvent>| {
+                    *mc_ns.lock().unwrap() += 1;
+                    let today_total = *tdc_ns.lock().unwrap() + *mc_ns.lock().unwrap();
+                    let _ = app_handle_emit.emit("keystroke_update", today_total);
+                });
+
+                match NSEvent::addGlobalMonitorForEventsMatchingMask_handler(
+                    NSEventMask::KeyDown,
+                    &handler,
+                ) {
+                    Some(monitor) => {
+                        // drop するとイベント監視が解除されるため意図的にリーク
+                        std::mem::forget(monitor);
                     }
-                }) {
-                    let _ = app_handle_rdev_err.emit("listener_error", format!("{e:?}"));
+                    None => {
+                        let _ = app_handle_err
+                            .emit("listener_error", "入力監視の開始に失敗しました");
+                    }
                 }
-            });
+                // handler は NSEvent が retain 済みのため drop しても監視は継続する
+            }
+
+            #[cfg(not(target_os = "macos"))]
+            {
+                let mc_rdev = minute_count_s.clone();
+                let tdc_rdev = today_db_count_s.clone();
+                let app_handle_rdev_emit = app.handle().clone();
+                let app_handle_rdev_err = app.handle().clone();
+                thread::spawn(move || {
+                    if let Err(e) = rdev::listen(move |event| {
+                        if matches!(event.event_type, rdev::EventType::KeyPress(_)) {
+                            *mc_rdev.lock().unwrap() += 1;
+                            let today_total =
+                                *tdc_rdev.lock().unwrap() + *mc_rdev.lock().unwrap();
+                            let _ = app_handle_rdev_emit.emit("keystroke_update", today_total);
+                        }
+                    }) {
+                        let _ = app_handle_rdev_err.emit("listener_error", format!("{e:?}"));
+                    }
+                });
+            }
 
             // ハートビート：初期表示・日付変更検知のため 1 秒ごとに emit
             let mc_emit = minute_count_s.clone();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -61,8 +61,12 @@ unsafe extern "C" fn tap_callback(
     const CG_EVENT_KEY_DOWN: u32 = 10;
     if event_type == CG_EVENT_KEY_DOWN {
         let data = &*(user_info as *const TapUserData);
-        *data.minute_count.lock().unwrap() += 1;
-        let today_total = *data.today_db_count.lock().unwrap() + *data.minute_count.lock().unwrap();
+        let count = {
+            let mut mc = data.minute_count.lock().unwrap();
+            *mc += 1;
+            *mc
+        };
+        let today_total = *data.today_db_count.lock().unwrap() + count;
         let _ = data.app_handle.emit("keystroke_update", today_total);
     }
     event
@@ -305,8 +309,7 @@ pub fn run() {
                 event: tauri::WindowEvent::CloseRequested { .. },
                 ..
             } => {
-                let db_path = app_handle.state::<DbPath>();
-                flush_minute_count(&minute_count, &today_db_count, &db_path.0);
+                // exit(0) が RunEvent::Exit を発火させるため、フラッシュは Exit 側に一本化する
                 app_handle.exit(0);
             }
             tauri::RunEvent::Exit => {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+#[cfg(target_os = "macos")]
 use std::ffi::c_void;
 use std::sync::{Arc, Mutex};
 use std::thread;


### PR DESCRIPTION
close #6

### 概要

macOS Tahoe (26) でキー入力時にアプリがクラッシュし、修正後もキーストロークがカウントされなかった問題を修正する。

### 背景

- rdev の CGEventTap コールバックが `TSMGetInputSourceProperty` を呼び出しているが、macOS Tahoe でこの API がメインキュー必須となり `dispatch_assert_queue` で SIGTRAP クラッシュが発生していた
- NSEvent グローバルモニターへの切り替えを試みたが、macOS Tahoe では Input Monitoring 権限ありでもイベントが配送されないことが判明した
- また macOS では赤×でウィンドウを閉じてもプロセスが生き続けるため、終了時の保存も機能していなかった

### 変更内容

- macOS のキーストローク監視を rdev (CGEventTap 経由) → CGEventTap 直接呼び出しに切り替え
  - カウントのみの最小限コールバックとすることで TSM API を呼ばず、クラッシュを回避
  - `RunEvent::Ready`（イベントループ起動後）で登録することで安定動作を確認
- `WindowEvent::CloseRequested` でフラッシュ後に `app_handle.exit(0)` を呼ぶことで、赤×終了時も保存されるよう修正
- macOS 固有の依存（`objc2-app-kit`・`block2`）を削除

### チェック項目

- [x] macOS Tahoe: 他アプリへのキー入力がカウントされること
- [x] macOS Tahoe: アプリ終了時（赤×・Cmd+Q）にカウントが保存されること
- [x] macOS Tahoe: キー入力時にクラッシュしないこと
- [x] Windows: 動作が壊れていないこと（rdev パスは変更なし）

### 備考

- macOS では NSEvent グローバルモニター（`addGlobalMonitorForEventsMatchingMask_handler`）が Tahoe で動作しない原因は不明。CGEventTap に切り替えることで解決した
- CGEventTap コールバックは TSM API を呼ばないため macOS Tahoe でも安全