### PR TITLE
feat(day-nav): 日付ナビゲーションと表示切り替えを実装する

### DIFF
--- a/.oxfmtignore
+++ b/.oxfmtignore
@@ -1,0 +1,1 @@
+src-tauri/

--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -1,0 +1,12 @@
+export default {
+  '*.vue': ['eslint --fix', 'stylelint --fix', 'oxfmt --write'],
+  '*.ts': ['eslint --fix', 'oxfmt --write'],
+  '*.css': ['stylelint --fix', 'oxfmt --write'],
+  '*.{json,md}': (files) => {
+    const applicable = files.filter((f) => !/[/\\]src-tauri[/\\]/.test(f));
+    if (!applicable.length) return [];
+    return [
+      `oxfmt --write --ignore-path=.oxfmtignore ${applicable.map((f) => JSON.stringify(f)).join(' ')}`,
+    ];
+  },
+};

--- a/package.json
+++ b/package.json
@@ -41,23 +41,5 @@
     "typescript-eslint": "^8.32.1",
     "vite": "^6.0.3",
     "vue-tsc": "^2.1.10"
-  },
-  "lint-staged": {
-    "*.vue": [
-      "eslint --fix",
-      "stylelint --fix",
-      "oxfmt --write"
-    ],
-    "*.ts": [
-      "eslint --fix",
-      "oxfmt --write"
-    ],
-    "*.css": [
-      "stylelint --fix",
-      "oxfmt --write"
-    ],
-    "*.{json,md}": [
-      "oxfmt --write --ignore-path=.oxfmtignore"
-    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "prepare": "husky",
     "lint": "eslint src/",
     "lint:style": "stylelint \"src/**/*.{vue,css}\"",
-    "format": "oxfmt --write src/",
-    "format:check": "oxfmt --check src/"
+    "format": "oxfmt --write --ignore-path=.oxfmtignore src/",
+    "format:check": "oxfmt --check --ignore-path=.oxfmtignore src/"
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.2.4",
@@ -57,7 +57,7 @@
       "oxfmt --write"
     ],
     "*.{json,md}": [
-      "oxfmt --write"
+      "oxfmt --write --ignore-path=.oxfmtignore"
     ]
   }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -16,7 +16,7 @@
         "width": 1000,
         "height": 870,
         "minWidth": 680,
-        "minHeight": 88
+        "minHeight": 200
       }
     ],
     "security": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -14,7 +14,7 @@
       {
         "title": "typemeter",
         "width": 1000,
-        "height": 940
+        "height": 870
       }
     ],
     "security": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -14,7 +14,9 @@
       {
         "title": "typemeter",
         "width": 1000,
-        "height": 870
+        "height": 870,
+        "minWidth": 680,
+        "minHeight": 88
       }
     ],
     "security": {

--- a/src/App.vue
+++ b/src/App.vue
@@ -87,7 +87,7 @@ const DAILY_GOAL = 10000;
 
       <!-- Main content card -->
       <main
-        class="flex-1 flex flex-col items-center bg-pond-color rounded-t-[35px] pt-10 px-6 pb-6 overflow-hidden"
+        class="flex-1 flex flex-col items-center bg-pond-color rounded-t-[35px] pt-10 px-6 pb-6 overflow-y-auto"
       >
         <!-- Date -->
         <p class="flex items-center gap-1 text-xl mb-4">
@@ -150,5 +150,13 @@ const DAILY_GOAL = 10000;
   width: 0.25em;
   margin-inline: -0.05em;
   text-align: center;
+}
+
+main {
+  scrollbar-width: none;
+}
+
+main::-webkit-scrollbar {
+  display: none;
 }
 </style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -70,6 +70,10 @@ const targetDateParts = computed(() => {
   return { year, month, day };
 });
 
+const displayChars = computed(() =>
+  displayTotal.value !== null ? displayTotal.value.toLocaleString('en-US').split('') : [],
+);
+
 const DAILY_GOAL = 10000;
 </script>
 
@@ -122,8 +126,8 @@ const DAILY_GOAL = 10000;
               class="flex justify-center text-[5rem] font-bold mb-8 leading-none"
             >
               <span
-                v-for="(char, i) in displayTotal.toLocaleString('en-US').split('')"
-                :key="i"
+                v-for="(char, i) in displayChars"
+                :key="displayChars.length - i"
                 :class="char === ',' ? 'count-sep' : 'count-digit'"
                 class="relative h-[1em]"
               >

--- a/src/App.vue
+++ b/src/App.vue
@@ -45,7 +45,12 @@ onUnmounted(() => {
   unlisteners.forEach((fn) => fn());
 });
 
-watch(targetDate, async (newDate) => {
+// < は過去方向（右スライド）、> / TODAY は未来方向（左スライド）
+const transitionDirection = ref<'left' | 'right'>('left');
+
+watch(targetDate, async (newDate, oldDate) => {
+  transitionDirection.value = newDate < oldDate ? 'right' : 'left';
+
   if (newDate === todayDate.value) {
     pastTotal.value = null;
     return;
@@ -85,42 +90,47 @@ const DAILY_GOAL = 10000;
         <div class="flex-1 flex justify-end"><ThemeToggle /></div>
       </header>
 
-      <!-- Main content card -->
-      <main
-        class="flex-1 flex flex-col items-center bg-pond-color rounded-t-[35px] pt-10 px-6 pb-6 overflow-y-auto"
-      >
-        <!-- Date -->
-        <p class="flex items-center gap-1 text-xl mb-4">
-          <span class="text-base-color">{{ targetDateParts.year }}</span>
-          <span class="text-sub-color">/</span>
-          <span class="text-base-color">{{ targetDateParts.month }}</span>
-          <span class="text-sub-color">/</span>
-          <span class="text-base-color">{{ targetDateParts.day }}</span>
-        </p>
-
-        <!-- Circular meter -->
-        <div class="-mb-5">
-          <MeterRing :value="displayTotal ?? 0" :goal="DAILY_GOAL" />
-        </div>
-
-        <!-- Keystroke count -->
-        <p
-          v-if="displayTotal !== null"
-          class="flex justify-center text-[5rem] font-bold mb-8 leading-none"
-        >
-          <span
-            v-for="(char, i) in displayTotal.toLocaleString('en-US').split('')"
-            :key="i"
-            :class="char === ',' ? 'count-sep' : 'count-digit'"
-            >{{ char }}</span
+      <!-- Main content card（背景は固定、内部コンテンツのみスライド） -->
+      <main class="flex-1 relative overflow-hidden bg-pond-color rounded-t-[35px]">
+        <Transition :name="`slide-${transitionDirection}`">
+          <div
+            :key="targetDate"
+            class="content-area absolute inset-0 flex flex-col items-center pt-10 px-6 pb-6 overflow-y-auto"
           >
-        </p>
-        <p v-else class="flex items-center justify-center h-[5rem] mb-8 text-base opacity-40">
-          Loading
-        </p>
+            <!-- Date -->
+            <p class="flex items-center gap-1 text-xl mb-4">
+              <span class="text-base-color">{{ targetDateParts.year }}</span>
+              <span class="text-sub-color">/</span>
+              <span class="text-base-color">{{ targetDateParts.month }}</span>
+              <span class="text-sub-color">/</span>
+              <span class="text-base-color">{{ targetDateParts.day }}</span>
+            </p>
 
-        <!-- Day stamps chart -->
-        <DayStamps :date="targetDate" class="-mt-8" />
+            <!-- Circular meter -->
+            <div class="-mb-5">
+              <MeterRing :value="displayTotal ?? 0" :goal="DAILY_GOAL" />
+            </div>
+
+            <!-- Keystroke count -->
+            <p
+              v-if="displayTotal !== null"
+              class="flex justify-center text-[5rem] font-bold mb-8 leading-none"
+            >
+              <span
+                v-for="(char, i) in displayTotal.toLocaleString('en-US').split('')"
+                :key="i"
+                :class="char === ',' ? 'count-sep' : 'count-digit'"
+                >{{ char }}</span
+              >
+            </p>
+            <p v-else class="flex items-center justify-center h-20 mb-8 text-base opacity-40">
+              Loading
+            </p>
+
+            <!-- Day stamps chart -->
+            <DayStamps :date="targetDate" class="-mt-8" />
+          </div>
+        </Transition>
       </main>
     </template>
   </div>
@@ -154,11 +164,65 @@ const DAILY_GOAL = 10000;
   text-align: center;
 }
 
-main {
+.content-area {
   scrollbar-width: none;
 }
 
-main::-webkit-scrollbar {
+.content-area::-webkit-scrollbar {
   display: none;
+}
+
+/* < ボタン: 旧コンテンツが右へ退場、新コンテンツが左から登場 */
+.slide-right-enter-active {
+  transition:
+    transform 0.2s ease-out,
+    opacity 0.15s ease,
+    filter 0.3s ease;
+}
+
+.slide-right-leave-active {
+  transition:
+    transform 0.2s ease-out,
+    opacity 0.1s ease,
+    filter 0.3s ease;
+}
+
+.slide-right-enter-from {
+  transform: translateX(-100%);
+  opacity: 0;
+  filter: blur(25px);
+}
+
+.slide-right-leave-to {
+  transform: translateX(100%);
+  opacity: 0;
+  filter: blur(25px);
+}
+
+/* > / TODAY ボタン: 旧コンテンツが左へ退場、新コンテンツが右から登場 */
+.slide-left-enter-active {
+  transition:
+    transform 0.2s ease-out,
+    opacity 0.15s ease,
+    filter 0.3s ease;
+}
+
+.slide-left-leave-active {
+  transition:
+    transform 0.2s ease-out,
+    opacity 0.1s ease,
+    filter 0.3s ease;
+}
+
+.slide-left-enter-from {
+  transform: translateX(100%);
+  opacity: 0;
+  filter: blur(25px);
+}
+
+.slide-left-leave-to {
+  transform: translateX(-100%);
+  opacity: 0;
+  filter: blur(25px);
 }
 </style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -115,7 +115,9 @@ const DAILY_GOAL = 10000;
             >{{ char }}</span
           >
         </p>
-        <p v-else class="text-base opacity-40">Loading</p>
+        <p v-else class="flex items-center justify-center h-[5rem] mb-8 text-base opacity-40">
+          Loading
+        </p>
 
         <!-- Day stamps chart -->
         <DayStamps :date="targetDate" class="-mt-8" />

--- a/src/App.vue
+++ b/src/App.vue
@@ -112,6 +112,10 @@ const DAILY_GOAL = 10000;
             </div>
 
             <!-- Keystroke count -->
+            <!--
+              外側の span がスロット（幅・高さ固定 + overflow-hidden）。
+              内側の span は :key="char" で値が変わると enter/leave アニメーションする。
+            -->
             <p
               v-if="displayTotal !== null"
               class="flex justify-center text-[5rem] font-bold mb-8 leading-none"
@@ -120,8 +124,14 @@ const DAILY_GOAL = 10000;
                 v-for="(char, i) in displayTotal.toLocaleString('en-US').split('')"
                 :key="i"
                 :class="char === ',' ? 'count-sep' : 'count-digit'"
-                >{{ char }}</span
+                class="relative h-[1em]"
               >
+                <Transition name="digit-roll">
+                  <span :key="char" class="absolute inset-0 flex items-center justify-center">{{
+                    char
+                  }}</span>
+                </Transition>
+              </span>
             </p>
             <p v-else class="flex items-center justify-center h-20 mb-8 text-base opacity-40">
               Loading
@@ -224,5 +234,26 @@ const DAILY_GOAL = 10000;
   transform: translateX(-100%);
   opacity: 0;
   filter: blur(25px);
+}
+
+/* 桁アニメーション: 旧桁が下へ退場、新桁が上から登場 */
+.digit-roll-enter-active,
+.digit-roll-leave-active {
+  transition:
+    transform 0.2s ease,
+    opacity 0.1s ease,
+    filter 0.3s ease;
+}
+
+.digit-roll-enter-from {
+  transform: translateY(-100%);
+  opacity: 0;
+  filter: blur(6px);
+}
+
+.digit-roll-leave-to {
+  transform: translateY(100%);
+  opacity: 0;
+  filter: blur(6px);
 }
 </style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -29,10 +29,11 @@ onMounted(async () => {
       todayTotal.value = total;
       const newTodayDate = new Date().toLocaleDateString('en-CA');
       if (newTodayDate !== todayDate.value) {
-        if (targetDate.value === todayDate.value) {
+        const wasToday = targetDate.value === todayDate.value;
+        todayDate.value = newTodayDate;
+        if (wasToday) {
           targetDate.value = newTodayDate;
         }
-        todayDate.value = newTodayDate;
       }
     }),
     await subscribeListenerError((message) => {

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,13 +1,24 @@
 <script setup lang="ts">
-import { onMounted, onUnmounted, ref } from 'vue';
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue';
 import DayNav from '@/components/DayNav.vue';
 import DayStamps from '@/components/DayStamps.vue';
 import MeterRing from '@/components/MeterRing.vue';
 import TabGroup from '@/components/TabGroup.vue';
 import ThemeToggle from '@/components/ThemeToggle.vue';
-import { subscribeKeystrokeUpdate, subscribeListenerError } from '@/lib/keystroke';
+import {
+  fetchHourlyCounts,
+  subscribeKeystrokeUpdate,
+  subscribeListenerError,
+} from '@/lib/keystroke';
+
+const todayDate = ref(new Date().toLocaleDateString('en-CA'));
+const targetDate = ref(todayDate.value);
+const isToday = computed(() => targetDate.value === todayDate.value);
 
 const todayTotal = ref<number | null>(null);
+const pastTotal = ref<number | null>(null);
+const displayTotal = computed(() => (isToday.value ? todayTotal.value : pastTotal.value));
+
 const listenerError = ref<string | null>(null);
 
 const unlisteners: Array<() => void> = [];
@@ -16,6 +27,13 @@ onMounted(async () => {
   unlisteners.push(
     await subscribeKeystrokeUpdate((total) => {
       todayTotal.value = total;
+      const newTodayDate = new Date().toLocaleDateString('en-CA');
+      if (newTodayDate !== todayDate.value) {
+        if (targetDate.value === todayDate.value) {
+          targetDate.value = newTodayDate;
+        }
+        todayDate.value = newTodayDate;
+      }
     }),
     await subscribeListenerError((message) => {
       listenerError.value = message;
@@ -27,10 +45,24 @@ onUnmounted(() => {
   unlisteners.forEach((fn) => fn());
 });
 
-const now = new Date();
-const dateYear = now.getFullYear();
-const dateMonth = String(now.getMonth() + 1).padStart(2, '0');
-const dateDay = String(now.getDate()).padStart(2, '0');
+watch(targetDate, async (newDate) => {
+  if (newDate === todayDate.value) {
+    pastTotal.value = null;
+    return;
+  }
+  try {
+    const counts = await fetchHourlyCounts(newDate);
+    pastTotal.value = counts.reduce((a, b) => a + b, 0);
+  } catch (err) {
+    console.error('[App] fetchHourlyCounts failed:', err);
+    pastTotal.value = null;
+  }
+});
+
+const targetDateParts = computed(() => {
+  const [year, month, day] = targetDate.value.split('-');
+  return { year, month, day };
+});
 
 const DAILY_GOAL = 10000;
 </script>
@@ -49,7 +81,7 @@ const DAILY_GOAL = 10000;
       <!-- Header -->
       <header class="flex items-center px-6 h-22 shrink-0">
         <div class="flex-1"><TabGroup /></div>
-        <DayNav />
+        <DayNav v-model="targetDate" :today-date="todayDate" />
         <div class="flex-1 flex justify-end"><ThemeToggle /></div>
       </header>
 
@@ -59,25 +91,25 @@ const DAILY_GOAL = 10000;
       >
         <!-- Date -->
         <p class="flex items-center gap-1 text-xl mb-4">
-          <span class="text-base-color">{{ dateYear }}</span>
+          <span class="text-base-color">{{ targetDateParts.year }}</span>
           <span class="text-sub-color">/</span>
-          <span class="text-base-color">{{ dateMonth }}</span>
+          <span class="text-base-color">{{ targetDateParts.month }}</span>
           <span class="text-sub-color">/</span>
-          <span class="text-base-color">{{ dateDay }}</span>
+          <span class="text-base-color">{{ targetDateParts.day }}</span>
         </p>
 
         <!-- Circular meter -->
         <div class="-mb-5">
-          <MeterRing :value="todayTotal ?? 0" :goal="DAILY_GOAL" />
+          <MeterRing :value="displayTotal ?? 0" :goal="DAILY_GOAL" />
         </div>
 
         <!-- Keystroke count -->
         <p
-          v-if="todayTotal !== null"
+          v-if="displayTotal !== null"
           class="flex justify-center text-[5rem] font-bold mb-8 leading-none"
         >
           <span
-            v-for="(char, i) in todayTotal.toLocaleString('en-US').split('')"
+            v-for="(char, i) in displayTotal.toLocaleString('en-US').split('')"
             :key="i"
             :class="char === ',' ? 'count-sep' : 'count-digit'"
             >{{ char }}</span
@@ -86,7 +118,7 @@ const DAILY_GOAL = 10000;
         <p v-else class="text-base opacity-40">Loading</p>
 
         <!-- Day stamps chart -->
-        <DayStamps class="-mt-8" />
+        <DayStamps :date="targetDate" class="-mt-8" />
       </main>
     </template>
   </div>

--- a/src/App.vue
+++ b/src/App.vue
@@ -51,9 +51,9 @@ const transitionDirection = ref<'left' | 'right'>('left');
 
 watch(targetDate, async (newDate, oldDate) => {
   transitionDirection.value = newDate < oldDate ? 'right' : 'left';
+  pastTotal.value = null;
 
   if (newDate === todayDate.value) {
-    pastTotal.value = null;
     return;
   }
   try {
@@ -61,7 +61,6 @@ watch(targetDate, async (newDate, oldDate) => {
     pastTotal.value = counts.reduce((a, b) => a + b, 0);
   } catch (err) {
     console.error('[App] fetchHourlyCounts failed:', err);
-    pastTotal.value = null;
   }
 });
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -5,13 +5,14 @@ import DayStamps from '@/components/DayStamps.vue';
 import MeterRing from '@/components/MeterRing.vue';
 import TabGroup from '@/components/TabGroup.vue';
 import ThemeToggle from '@/components/ThemeToggle.vue';
+import { formatDate } from '@/lib/date';
 import {
   fetchHourlyCounts,
   subscribeKeystrokeUpdate,
   subscribeListenerError,
 } from '@/lib/keystroke';
 
-const todayDate = ref(new Date().toLocaleDateString('en-CA'));
+const todayDate = ref(formatDate(new Date()));
 const targetDate = ref(todayDate.value);
 const isToday = computed(() => targetDate.value === todayDate.value);
 
@@ -27,7 +28,7 @@ onMounted(async () => {
   unlisteners.push(
     await subscribeKeystrokeUpdate((total) => {
       todayTotal.value = total;
-      const newTodayDate = new Date().toLocaleDateString('en-CA');
+      const newTodayDate = formatDate(new Date());
       if (newTodayDate !== todayDate.value) {
         const wasToday = targetDate.value === todayDate.value;
         todayDate.value = newTodayDate;

--- a/src/components/DayNav.vue
+++ b/src/components/DayNav.vue
@@ -23,7 +23,9 @@ const addDays = (date: string, days: number): string => {
 };
 
 const goPrev = () => emit('update:modelValue', addDays(props.modelValue, -1));
-const goToday = () => emit('update:modelValue', props.todayDate);
+const goToday = () => {
+  if (!isToday.value) emit('update:modelValue', props.todayDate);
+};
 const goNext = () => {
   if (!isToday.value) emit('update:modelValue', addDays(props.modelValue, 1));
 };
@@ -34,8 +36,10 @@ const goNext = () => {
     <NavButton aria-label="前の日" @click="goPrev">
       <ChevronLeft :size="20" />
     </NavButton>
-    <NavButton @click="goToday"><span class="translate-y-0.75">TODAY</span></NavButton>
-    <NavButton :disabled="isToday" aria-label="次の日" @click="goNext">
+    <NavButton :locked="isToday" @click="goToday"
+      ><span class="translate-y-0.75">TODAY</span></NavButton
+    >
+    <NavButton :locked="isToday" aria-label="次の日" @click="goNext">
       <ChevronRight :size="20" />
     </NavButton>
   </div>

--- a/src/components/DayNav.vue
+++ b/src/components/DayNav.vue
@@ -2,16 +2,40 @@
 <!-- App.vue ヘッダー中央に配置される -->
 <script setup lang="ts">
 import { ChevronLeft, ChevronRight } from 'lucide-vue-next';
+import { computed } from 'vue';
 import NavButton from '@/components/NavButton.vue';
+
+const props = defineProps<{
+  modelValue: string; // ターゲット日付（YYYY-MM-DD）
+  todayDate: string; // 今日の日付（YYYY-MM-DD）
+}>();
+
+const emit = defineEmits<{
+  'update:modelValue': [date: string];
+}>();
+
+const isToday = computed(() => props.modelValue === props.todayDate);
+
+const addDays = (date: string, days: number): string => {
+  const d = new Date(`${date}T00:00:00`);
+  d.setDate(d.getDate() + days);
+  return d.toLocaleDateString('en-CA');
+};
+
+const goPrev = () => emit('update:modelValue', addDays(props.modelValue, -1));
+const goToday = () => emit('update:modelValue', props.todayDate);
+const goNext = () => {
+  if (!isToday.value) emit('update:modelValue', addDays(props.modelValue, 1));
+};
 </script>
 
 <template>
   <div class="flex items-center gap-1">
-    <NavButton aria-label="前の日">
+    <NavButton aria-label="前の日" @click="goPrev">
       <ChevronLeft :size="20" />
     </NavButton>
-    <NavButton><span class="translate-y-0.75">TODAY</span></NavButton>
-    <NavButton aria-label="次の日">
+    <NavButton @click="goToday"><span class="translate-y-0.75">TODAY</span></NavButton>
+    <NavButton :disabled="isToday" aria-label="次の日" @click="goNext">
       <ChevronRight :size="20" />
     </NavButton>
   </div>

--- a/src/components/DayNav.vue
+++ b/src/components/DayNav.vue
@@ -4,6 +4,7 @@
 import { ChevronLeft, ChevronRight } from 'lucide-vue-next';
 import { computed } from 'vue';
 import NavButton from '@/components/NavButton.vue';
+import { formatDate } from '@/lib/date';
 
 const props = defineProps<{
   modelValue: string; // ターゲット日付（YYYY-MM-DD）
@@ -19,7 +20,7 @@ const isToday = computed(() => props.modelValue === props.todayDate);
 const addDays = (date: string, days: number): string => {
   const d = new Date(`${date}T00:00:00`);
   d.setDate(d.getDate() + days);
-  return d.toLocaleDateString('en-CA');
+  return formatDate(d);
 };
 
 const goPrev = () => emit('update:modelValue', addDays(props.modelValue, -1));

--- a/src/components/DayStamps.vue
+++ b/src/components/DayStamps.vue
@@ -1,20 +1,25 @@
-<!-- 今日の時間帯別タイプ数をドットグリッドで可視化するスタンプチャート -->
+<!-- 指定日の時間帯別タイプ数をドットグリッドで可視化するスタンプチャート -->
 <!-- x 軸 = 時間帯（0〜23時）、y 軸 = カウントレベル（1000 刻み） -->
-<!-- App.vue メインカードから <DayStamps /> として呼ばれる -->
+<!-- App.vue メインカードから <DayStamps :date="targetDate" /> として呼ばれる -->
 <script setup lang="ts">
 import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue';
 import { fetchHourlyCounts, subscribeKeystrokeUpdate } from '@/lib/keystroke';
 
+const props = defineProps<{
+  date: string; // YYYY-MM-DD
+}>();
+
 const currentHour = ref(new Date().getHours());
+
+// 今日の日付を追跡（日またぎ検知に使用）
+const todayDate = ref(new Date().toLocaleDateString('en-CA'));
+const isToday = computed(() => props.date === todayDate.value);
 
 const hourlyData = ref<number[]>(Array(24).fill(0));
 
-// 今日の日付のみリアルタイム更新する（他の日付は onMounted の一度取得のみ）
-const todayDate = ref(new Date().toLocaleDateString('en-CA')); // YYYY-MM-DD
-
-const loadTodayHourlyData = async () => {
+const loadHourlyData = async (date: string) => {
   try {
-    hourlyData.value = await fetchHourlyCounts(todayDate.value);
+    hourlyData.value = await fetchHourlyCounts(date);
   } catch (err) {
     console.error('[DayStamps] fetchHourlyCounts failed:', err);
   }
@@ -22,27 +27,51 @@ const loadTodayHourlyData = async () => {
 
 let unlisten: (() => void) | null = null;
 
-onMounted(async () => {
-  await loadTodayHourlyData();
+const unsubscribe = () => {
+  unlisten?.();
+  unlisten = null;
+};
+
+const subscribeToday = async () => {
   try {
     unlisten = await subscribeKeystrokeUpdate(() => {
       const now = new Date();
-      const newDate = now.toLocaleDateString('en-CA');
+      const newTodayDate = now.toLocaleDateString('en-CA');
       currentHour.value = now.getHours();
-      if (newDate !== todayDate.value) {
-        todayDate.value = newDate;
-        hourlyData.value = Array(24).fill(0);
+      if (newTodayDate !== todayDate.value) {
+        todayDate.value = newTodayDate;
+        // 日またぎ: props.date が旧・今日になったため購読を停止
+        unsubscribe();
+        return;
       }
-      loadTodayHourlyData();
+      loadHourlyData(props.date);
     });
   } catch (err) {
     console.error('[DayStamps] subscribeKeystrokeUpdate failed:', err);
   }
+};
+
+onMounted(async () => {
+  await loadHourlyData(props.date);
+  if (isToday.value) {
+    await subscribeToday();
+  }
 });
 
-onUnmounted(() => {
-  unlisten?.();
-});
+// date prop の変化（ユーザーのナビゲーション）に対応
+watch(
+  () => props.date,
+  async (newDate) => {
+    unsubscribe();
+    hourlyData.value = Array(24).fill(0);
+    await loadHourlyData(newDate);
+    if (newDate === todayDate.value) {
+      await subscribeToday();
+    }
+  },
+);
+
+onUnmounted(unsubscribe);
 
 const hoveredHour = ref<number | null>(null);
 
@@ -178,7 +207,7 @@ const dotFill = (hour: number, level: number): string => {
  *   - それ以外: pond-color（実質不可視）
  */
 const labelClass = (hour: number): string => {
-  if (hour === currentHour.value) return 'fill-accent-color! font-bold';
+  if (isToday.value && hour === currentHour.value) return 'fill-accent-color! font-bold';
   if (ALWAYS_VISIBLE_HOURS.has(hour)) return 'fill-sub-color';
   return 'fill-pond-color';
 };

--- a/src/components/DayStamps.vue
+++ b/src/components/DayStamps.vue
@@ -3,6 +3,7 @@
 <!-- App.vue メインカードから <DayStamps :date="targetDate" /> として呼ばれる -->
 <script setup lang="ts">
 import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue';
+import { formatDate } from '@/lib/date';
 import { fetchHourlyCounts, subscribeKeystrokeUpdate } from '@/lib/keystroke';
 
 const props = defineProps<{
@@ -12,7 +13,7 @@ const props = defineProps<{
 const currentHour = ref(new Date().getHours());
 
 // 今日の日付を追跡（日またぎ検知に使用）
-const todayDate = ref(new Date().toLocaleDateString('en-CA'));
+const todayDate = ref(formatDate(new Date()));
 const isToday = computed(() => props.date === todayDate.value);
 
 const hourlyData = ref<number[]>(Array(24).fill(0));
@@ -36,7 +37,7 @@ const subscribeToday = async () => {
   try {
     unlisten = await subscribeKeystrokeUpdate(() => {
       const now = new Date();
-      const newTodayDate = now.toLocaleDateString('en-CA');
+      const newTodayDate = formatDate(now);
       currentHour.value = now.getHours();
       if (newTodayDate !== todayDate.value) {
         todayDate.value = newTodayDate;

--- a/src/components/NavButton.vue
+++ b/src/components/NavButton.vue
@@ -1,25 +1,72 @@
 <!-- ナビゲーション共通ボタン -->
 <!-- ホバー時: bg-pond-color / active 時: bg-base-color -->
+<!-- locked 時: sub-color 表示でクリック可能、押下するとシェイクアニメーション -->
 <!-- TabGroup・DayNav 内のボタンから使用される -->
 <script setup lang="ts">
+import { ref } from 'vue';
+
 defineProps<{
   active?: boolean;
-  disabled?: boolean;
+  locked?: boolean;
 }>();
+
+const isShaking = ref(false);
+
+const triggerShake = () => {
+  if (isShaking.value) return;
+  isShaking.value = true;
+  setTimeout(() => {
+    isShaking.value = false;
+  }, 400);
+};
 </script>
 
 <template>
   <button
-    :disabled="disabled"
-    class="inline-flex items-center gap-1.5 px-4 py-2 min-h-11 rounded-full border-0 text-base font-bold transition-colors duration-200 ease-in-out"
-    :class="
-      disabled
-        ? 'text-sub-color cursor-default'
+    class="inline-flex items-center gap-1.5 px-4 py-2 min-h-11 rounded-full border-0 text-base font-bold cursor-pointer transition-colors duration-200 ease-in-out"
+    :class="[
+      isShaking ? 'shake' : '',
+      locked
+        ? 'text-sub-color hover:bg-sub-color/20'
         : active
-          ? 'bg-base-color text-background-color cursor-pointer'
-          : 'bg-transparent text-base-color hover:bg-sub-color/20 cursor-pointer'
+          ? 'bg-base-color text-background-color'
+          : 'bg-transparent text-base-color hover:bg-sub-color/20',
+    ]"
+    @click="
+      () => {
+        if (locked) triggerShake();
+      }
     "
   >
     <slot />
   </button>
 </template>
+
+<style scoped>
+@keyframes shake {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+
+  20% {
+    transform: translateX(-3px);
+  }
+
+  40% {
+    transform: translateX(3px);
+  }
+
+  60% {
+    transform: translateX(-2.5px);
+  }
+
+  80% {
+    transform: translateX(2px);
+  }
+}
+
+.shake {
+  animation: shake 0.3s ease-in-out;
+}
+</style>

--- a/src/components/NavButton.vue
+++ b/src/components/NavButton.vue
@@ -4,16 +4,20 @@
 <script setup lang="ts">
 defineProps<{
   active?: boolean;
+  disabled?: boolean;
 }>();
 </script>
 
 <template>
   <button
-    class="inline-flex items-center gap-1.5 px-4 py-2 min-h-11 rounded-full border-0 text-base font-bold cursor-pointer transition-colors duration-200 ease-in-out"
+    :disabled="disabled"
+    class="inline-flex items-center gap-1.5 px-4 py-2 min-h-11 rounded-full border-0 text-base font-bold transition-colors duration-200 ease-in-out"
     :class="
-      active
-        ? 'bg-base-color text-background-color'
-        : 'bg-transparent text-base-color hover:bg-sub-color/20'
+      disabled
+        ? 'text-sub-color cursor-default'
+        : active
+          ? 'bg-base-color text-background-color cursor-pointer'
+          : 'bg-transparent text-base-color hover:bg-sub-color/20 cursor-pointer'
     "
   >
     <slot />

--- a/src/components/TabGroup.vue
+++ b/src/components/TabGroup.vue
@@ -11,7 +11,7 @@ import NavButton from '@/components/NavButton.vue';
       <CalendarDays :size="18" />
       <span class="translate-y-0.75">DAY</span>
     </NavButton>
-    <NavButton role="tab" aria-selected="false">
+    <NavButton :locked="true" role="tab" aria-selected="false">
       <CalendarRange :size="18" />
       <span class="translate-y-0.75">DAYS</span>
     </NavButton>

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -1,0 +1,12 @@
+/**
+ * @function DateオブジェクトをYYYY-MM-DD形式の文字列に変換する
+ *
+ * @param date 変換対象の Date オブジェクト
+ * @returns YYYY-MM-DD 形式の日付文字列
+ */
+export const formatDate = (date: Date): string => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};


### PR DESCRIPTION
close #

### 概要

DAY ビューにおける日付ナビゲーション（前の日 / TODAY / 次の日）と、過去日のキーストロークデータ表示を実装する。

### 変更内容

- **日付ナビゲーション**
  - `DayNav`: `< TODAY >` ボタンの操作を実装。今日の場合は `>` / `TODAY` を locked 状態（グレー表示 + シェイクアニメーション）にする
  - `NavButton`: `locked` prop を追加。クリック時に左右シェイクアニメーションで操作限界を伝える（`disabled` は廃止）
  - `TabGroup`: 未実装の DAYS ボタンを locked に変更

- **過去日表示**
  - `DayStamps`: `date` prop を追加。今日はリアルタイム購読、過去日は一度のみフェッチ
  - `App.vue`: `targetDate` / `todayDate` を追加。日付表示・合計・チャートをリアクティブ化。過去日は `fetchHourlyCounts` の合計をトータルに使用

- **UI 改善**
  - ウィンドウ最小サイズを minWidth=680 / minHeight=88 に設定
  - メインカードを `overflow-y-auto`（スクロールバー非表示）に変更
  - Loading 要素の高さをキー数表示と揃えてレイアウトシフトを防止
  - 日付切り替え時にカード背景を固定したままコンテンツをスライド＆ブラーでトランジション
  - キーストローク数の変化桁にスロットアニメーション（上下スライド＋フェード＋ブラー）を追加

- **ツール設定**
  - `.oxfmtignore` を追加して `src-tauri/` を oxfmt 対象から除外
  - `package.json` の `format` / `format:check` / lint-staged に `--ignore-path=.oxfmtignore` を追加

### チェック項目

- [x] 前の日 / TODAY / 次の日 の操作が正しく動作するか
- [x] 今日の場合に `>` / `TODAY` が locked（グレー＋シェイク）になるか
- [x] 過去日のデータが正しく表示されるか（合計・時間帯チャート）
- [x] 日付変更時のスライドトランジションが正しい向きで動作するか
- [x] ウィンドウを小さくしたときにスクロールできるか

### 備考

- 日またぎ（0時をまたいで起動し続けた場合）の自動追従は `keystroke_update` イベント内で検知・対応済み
- Rust 側の変更はなし（既存の `get_hourly_counts` が任意日付に対応しているため）