### PR TITLE
ci(release): release ブランチへの push で全 OS 向けビルドと GitHub Release 作成を自動化

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,52 @@
+name: Release
+
+on:
+  push:
+    branches: [release]
+
+jobs:
+  build:
+    name: Build (${{ matrix.platform }})
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [windows-latest, macos-latest, ubuntu-22.04]
+
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install Frontend Dependencies
+        run: bun install
+
+      - name: Install Tauri System Dependencies
+        if: matrix.platform == 'ubuntu-22.04'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Build and Publish Release
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tagName: v__VERSION__
+          releaseName: v__VERSION__
+          releaseDraft: true
+          prerelease: true

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4171,7 +4171,7 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typemeter"
-version = "0.1.0"
+version = "0.1.0-beta.1"
 dependencies = [
  "chrono",
  "rdev",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "typemeter"
-version = "0.1.0"
+version = "0.1.0-beta.1"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -32,6 +32,11 @@
       "icons/128x128@2x.png",
       "icons/icon.icns",
       "icons/icon.ico"
-    ]
+    ],
+    "windows": {
+      "wix": {
+        "version": "0.1.0.1"
+      }
+    }
   }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "typemeter",
-  "version": "0.1.0",
+  "version": "0.1.0-beta.1",
   "identifier": "com.taish.typemeter",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
### 背景

ベータ版リリースに向けて、配布用バイナリのビルドと GitHub Release への公開を自動化したい。

### 概要

`release` ブランチへの push をトリガーに、3 プラットフォーム向けバイナリをビルドしてドラフト Release を作成する CI を追加する。

### 変更内容

- `.github/workflows/release.yml` を新規追加
  - `release` ブランチへの push をトリガーに実行
  - Windows / macOS / Linux を matrix で並列ビルド
  - `tauri-apps/tauri-action` で GitHub Release（Draft・prerelease）を自動作成
  - 成果物: Windows `.msi` / `.exe`、macOS `.dmg`、Linux `.deb` / `.AppImage`
- バージョンを `0.1.0` → `0.1.0-beta.1` に変更（`tauri.conf.json`、`Cargo.toml`）

### チェック項目

- [ ] ワークフローの構成（matrix、依存関係のインストール手順）に問題がないか
- [ ] Draft Release として作成されるため、Publish は人間が手動で行う点を確認

### 備考

- `macos-latest` ランナーは Apple Silicon（arm64）のため、Intel Mac 向けバイナリは生成されない。初回ベータとして許容とする
- コード署名なしのビルドのため、Windows の SmartScreen・macOS の Gatekeeper 警告が出る可能性あり