### PR TITLE
fix(ci): GITHUB_TOKEN に contents: write 権限を付与して Release 作成を許可

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [release]
 
+permissions:
+  contents: write
+
 jobs:
   build:
     name: Build (${{ matrix.platform }})


### PR DESCRIPTION
### 背景

release ブランチへの push で CI が動いたが、全 OS で GitHub Release の作成に失敗した。

### 概要

`GITHUB_TOKEN` のデフォルト権限は read-only のため、Release 作成に必要な `contents: write` を明示的に付与する。

### 変更内容

- `.github/workflows/release.yml` にワークフローレベルの `permissions: contents: write` を追加

### チェック項目

- [ ] 3 プラットフォーム（Windows / macOS / Linux）すべてで Release 作成まで通ることを確認