### PR TITLE
docs(release): リリースノートのテンプレートを追加

### DIFF
--- a/.github/RELEASE_TEMPLATE.md
+++ b/.github/RELEASE_TEMPLATE.md
@@ -27,8 +27,12 @@ It counts your keystrokes without ever recording what you type, and all data sta
 > [!NOTE]
 > 🍎 **macOS users**:
 >
-> - The app is not code-signed. On first launch, Gatekeeper may block it.
-> - Go to System Settings → Privacy & Security and click "Open Anyway".
+> - The app is not code-signed. After moving it to the Applications folder, open Terminal and run the following command:
+>   ```sh
+>   sudo xattr -d com.apple.quarantine /Applications/typemeter.app
+>   ```
+> - On first launch, Gatekeeper may block it.
+> - Go to System Settings → Privacy & Security → Input Monitoring, then turn on the toggle for typemeter.app.
 >
 > 🪟 **Windows users**:
 >

--- a/.github/RELEASE_TEMPLATE.md
+++ b/.github/RELEASE_TEMPLATE.md
@@ -16,13 +16,13 @@ It counts your keystrokes without ever recording what you type, and all data sta
 
 ## 📁 Downloads
 
-| OS                    | File                                                                             |
-| --------------------- | -------------------------------------------------------------------------------- |
-| Windows               | `typemeter_0.1.0-beta.1_x64_en-US.msi` or `typemeter_0.1.0-beta.1_x64-setup.exe` |
-| macOS (Apple Silicon) | `typemeter_0.1.0-beta.1_aarch64.dmg`                                             |
-| Linux (deb)           | `typemeter_0.1.0-beta.1_amd64.deb`                                               |
-| Linux (AppImage)      | `typemeter_0.1.0-beta.1_amd64.AppImage`                                          |
-| Linux (rpm)           | `typemeter-0.1.0-beta.1-1.x86_64.rpm`                                            |
+| OS                    | File                                                                       |
+| --------------------- | -------------------------------------------------------------------------- |
+| Windows               | `typemeter_{version}_x64_en-US.msi` or `typemeter_{version}_x64-setup.exe` |
+| macOS (Apple Silicon) | `typemeter_{version}_aarch64.dmg`                                          |
+| Linux (deb)           | `typemeter_{version}_amd64.deb`                                            |
+| Linux (AppImage)      | `typemeter_{version}_amd64.AppImage`                                       |
+| Linux (rpm)           | `typemeter-{version}-1.x86_64.rpm`                                         |
 
 > [!NOTE]
 > 🍎 **macOS users**:

--- a/.github/RELEASE_TEMPLATE.md
+++ b/.github/RELEASE_TEMPLATE.md
@@ -6,11 +6,13 @@
 Typemeter is a local activity meter for your typing — like a pedometer, but for your keyboard.
 It counts your keystrokes without ever recording what you type, and all data stays on your device.
 
-## ✨ Features
+## ✨ New Features
 
-- Real-time keystroke counting and logging
-- Dashboard to review your daily keystroke history
-- Fully local — no network requests, no cloud sync
+-
+
+## 🐛 Bug Fixes
+
+-
 
 ## 📁 Downloads
 

--- a/.github/RELEASE_TEMPLATE.md
+++ b/.github/RELEASE_TEMPLATE.md
@@ -1,0 +1,41 @@
+> [!WARNING]
+> ⚠️ This is a **beta release**. Unexpected behavior may occur. If you find any issues, please report them in [Issues](https://github.com/otTATto/typemeter/issues).
+
+## ⌨️ What is Typemeter?
+
+Typemeter is a local activity meter for your typing — like a pedometer, but for your keyboard.
+It counts your keystrokes without ever recording what you type, and all data stays on your device.
+
+## ✨ Features
+
+- Real-time keystroke counting and logging
+- Dashboard to review your daily keystroke history
+- Fully local — no network requests, no cloud sync
+
+## 📁 Downloads
+
+| OS                    | File                                                                             |
+| --------------------- | -------------------------------------------------------------------------------- |
+| Windows               | `typemeter_0.1.0-beta.1_x64_en-US.msi` or `typemeter_0.1.0-beta.1_x64-setup.exe` |
+| macOS (Apple Silicon) | `typemeter_0.1.0-beta.1_aarch64.dmg`                                             |
+| Linux (deb)           | `typemeter_0.1.0-beta.1_amd64.deb`                                               |
+| Linux (AppImage)      | `typemeter_0.1.0-beta.1_amd64.AppImage`                                          |
+| Linux (rpm)           | `typemeter-0.1.0-beta.1-1.x86_64.rpm`                                            |
+
+> [!NOTE]
+> 🍎 **macOS users**:
+>
+> - The app is not code-signed. On first launch, Gatekeeper may block it.
+> - Go to System Settings → Privacy & Security and click "Open Anyway".
+>
+> 🪟 **Windows users**:
+>
+> - If SmartScreen shows a warning, click "More info" → "Run anyway".
+
+## 🛠️ Known Issues
+
+- N/A
+
+## 📝 Feedback
+
+Bug reports and feature requests are welcome via [Issues](https://github.com/otTATto/typemeter/issues).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,18 @@ jobs:
         with:
           workspaces: src-tauri
 
+      - name: Read Release Notes
+        id: release_notes
+        shell: bash
+        run: |
+          VERSION=$(jq -r '.version' src-tauri/tauri.conf.json)
+          body=$(cat "docs/releases/v${VERSION}.md")
+          {
+            echo "body<<EOF"
+            echo "$body"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Build and Publish Release
         uses: tauri-apps/tauri-action@v0
         env:
@@ -51,5 +63,6 @@ jobs:
         with:
           tagName: v__VERSION__
           releaseName: v__VERSION__
+          releaseBody: ${{ steps.release_notes.outputs.body }}
           releaseDraft: true
           prerelease: true

--- a/README.md
+++ b/README.md
@@ -63,3 +63,39 @@ bun run tauri build
 ```
 
 The installer is generated in `src-tauri/target/release/bundle/`.
+
+## How to Release
+
+### 1. Bump the version
+
+Update the following two fields in `src-tauri/tauri.conf.json`:
+
+| Field                        | Platform      | Example                                  |
+| ---------------------------- | ------------- | ---------------------------------------- |
+| `version`                    | macOS / Linux | `0.2.0`                                  |
+| `bundle.windows.wix.version` | Windows       | `0.2.0.0` (must follow `x.y.z.w` format) |
+
+### 2. Create the release note
+
+```sh
+bun run release:note v0.2.0
+```
+
+This generates `docs/releases/v0.2.0.md` from the template in `.github/RELEASE_TEMPLATE.md`.
+
+### 3. Edit the release note
+
+Fill in the **New Features** and **Bug Fixes** sections in `docs/releases/v0.2.0.md`.
+
+### 4. Commit and merge into the release branch
+
+```sh
+git add src-tauri/tauri.conf.json docs/releases/v0.2.0.md
+git commit -m "release: v0.2.0"
+```
+
+Merge (or push) the commit into the `release` branch. GitHub Actions will then build the app for all platforms and create a **draft** GitHub Release using the release note as the body.
+
+### 5. Publish the release
+
+Once all builds succeed, open the draft release on GitHub, verify the attached assets, and publish it.

--- a/docs/releases/v0.1.0-beta.1.md
+++ b/docs/releases/v0.1.0-beta.1.md
@@ -6,13 +6,11 @@
 Typemeter is a local activity meter for your typing — like a pedometer, but for your keyboard.
 It counts your keystrokes without ever recording what you type, and all data stays on your device.
 
-## ✨ New Features
+## ✨ Features
 
--
-
-## 🐛 Bug Fixes
-
--
+- Real-time keystroke counting and logging
+- Dashboard to review your daily keystroke history
+- Fully local — no network requests, no cloud sync
 
 ## 📁 Downloads
 

--- a/docs/releases/v0.1.0-beta.1.md
+++ b/docs/releases/v0.1.0-beta.1.md
@@ -1,0 +1,47 @@
+> [!WARNING]
+> ⚠️ This is a **beta release**. Unexpected behavior may occur. If you find any issues, please report them in [Issues](https://github.com/otTATto/typemeter/issues).
+
+## ⌨️ What is Typemeter?
+
+Typemeter is a local activity meter for your typing — like a pedometer, but for your keyboard.
+It counts your keystrokes without ever recording what you type, and all data stays on your device.
+
+## ✨ New Features
+
+-
+
+## 🐛 Bug Fixes
+
+-
+
+## 📁 Downloads
+
+| OS                    | File                                                                             |
+| --------------------- | -------------------------------------------------------------------------------- |
+| Windows               | `typemeter_0.1.0-beta.1_x64_en-US.msi` or `typemeter_0.1.0-beta.1_x64-setup.exe` |
+| macOS (Apple Silicon) | `typemeter_0.1.0-beta.1_aarch64.dmg`                                             |
+| Linux (deb)           | `typemeter_0.1.0-beta.1_amd64.deb`                                               |
+| Linux (AppImage)      | `typemeter_0.1.0-beta.1_amd64.AppImage`                                          |
+| Linux (rpm)           | `typemeter-0.1.0-beta.1-1.x86_64.rpm`                                            |
+
+> [!NOTE]
+> 🍎 **macOS users**:
+>
+> - The app is not code-signed. After moving it to the Applications folder, open Terminal and run the following command:
+>   ```sh
+>   sudo xattr -d com.apple.quarantine /Applications/typemeter.app
+>   ```
+> - On first launch, Gatekeeper may block it.
+> - Go to System Settings → Privacy & Security → Input Monitoring, then turn on the toggle for typemeter.app.
+>
+> 🪟 **Windows users**:
+>
+> - If SmartScreen shows a warning, click "More info" → "Run anyway".
+
+## 🛠️ Known Issues
+
+- N/A
+
+## 📝 Feedback
+
+Bug reports and feature requests are welcome via [Issues](https://github.com/otTATto/typemeter/issues).

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "lint": "eslint src/",
     "lint:style": "stylelint \"src/**/*.{vue,css}\"",
     "format": "oxfmt --write --ignore-path=.oxfmtignore src/",
-    "format:check": "oxfmt --check --ignore-path=.oxfmtignore src/"
+    "format:check": "oxfmt --check --ignore-path=.oxfmtignore src/",
+    "release:note": "bun scripts/create-release-note.js"
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.2.4",

--- a/scripts/create-release-note.js
+++ b/scripts/create-release-note.js
@@ -1,0 +1,45 @@
+#!/usr/bin/env bun
+/**
+ * リリースノートのひな形を生成するスクリプト。
+ *
+ * `.github/RELEASE_TEMPLATE.md` をもとに `docs/releases/v{version}.md` を作成する。
+ * `{version}` プレースホルダーは指定されたバージョン番号に置換される。
+ *
+ * 生成したファイルを編集・コミットしておくことで、release ブランチへのプッシュ時に
+ * GitHub Actions がそのファイルを GitHub Release の本文として自動的に使用する。
+ *
+ * Usage:
+ *   bun run release:note <version>
+ *
+ * Example:
+ *   bun run release:note v0.2.0
+ *   → docs/releases/v0.2.0.md を生成
+ */
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'fs'
+import { join, dirname } from 'path'
+import { fileURLToPath } from 'url'
+
+const version = process.argv[2]
+if (!version) {
+  console.error('Usage: bun scripts/create-release-note.js <version>')
+  console.error('Example: bun scripts/create-release-note.js v0.1.0')
+  process.exit(1)
+}
+
+const normalizedVersion = version.startsWith('v') ? version.slice(1) : version
+const tagVersion = `v${normalizedVersion}`
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..')
+const outputPath = join(root, 'docs', 'releases', `${tagVersion}.md`)
+
+if (existsSync(outputPath)) {
+  console.error(`Already exists: ${outputPath}`)
+  process.exit(1)
+}
+
+const template = readFileSync(join(root, '.github', 'RELEASE_TEMPLATE.md'), 'utf-8')
+const content = template.replaceAll('{version}', normalizedVersion)
+
+mkdirSync(join(root, 'docs', 'releases'), { recursive: true })
+writeFileSync(outputPath, content)
+console.log(`Created: docs/releases/${tagVersion}.md`)

--- a/scripts/create-release-note.js
+++ b/scripts/create-release-note.js
@@ -20,7 +20,7 @@ import { join, dirname } from 'path'
 import { fileURLToPath } from 'url'
 
 const version = process.argv[2]
-if (!version) {
+if (!version || version.includes('/') || version.includes('\\')) {
   console.error('Usage: bun scripts/create-release-note.js <version>')
   console.error('Example: bun scripts/create-release-note.js v0.1.0')
   process.exit(1)
@@ -37,7 +37,12 @@ if (existsSync(outputPath)) {
   process.exit(1)
 }
 
-const template = readFileSync(join(root, '.github', 'RELEASE_TEMPLATE.md'), 'utf-8')
+const templatePath = join(root, '.github', 'RELEASE_TEMPLATE.md')
+if (!existsSync(templatePath)) {
+  console.error(`Template file not found: ${templatePath}`)
+  process.exit(1)
+}
+const template = readFileSync(templatePath, 'utf-8')
 const content = template.replaceAll('{version}', normalizedVersion)
 
 mkdirSync(join(root, 'docs', 'releases'), { recursive: true })


### PR DESCRIPTION
### 概要

リリースノートをローカルにも保持し、GitHub Release と連携させる仕組みを整備する。

### 変更内容

- `.github/RELEASE_TEMPLATE.md` を新規追加
  - 冒頭にベータ版の警告（`[!WARNING]`）
  - ✨ Features / 🐛 Bug Fixes の汎用セクション構成
  - Downloads テーブル（OS 別ファイル名）
  - macOS / Windows 向けの署名なし警告（`[!NOTE]`）
  - Known Issues / Feedback セクション
- `scripts/create-release-note.js` を新規追加
  - `bun run release:note <version>` でテンプレートから `docs/releases/v{version}.md` を生成する
- `package.json` に `release:note` スクリプトを追加
- `.github/workflows/release.yml` を更新
  - `docs/releases/v{version}.md` を読み込み、GitHub Release の本文に反映するよう変更
- `docs/releases/v0.1.0-beta.1.md` を追加（公開済みリリースの内容を記録）
- `README.md` にリリース手順（How to Release）を追記

### チェック項目

- [ ] テンプレートの内容・構成に問題がないか
- [ ] `bun run release:note` の動作に問題がないか
- [ ] リリースワークフローの変更に問題がないか
- [ ] README のリリース手順が正確か