### PR TITLE
fix(keystroke): キーの長押しによる無限カウントを修正

### DIFF
--- a/src-tauri/src/keystroke.rs
+++ b/src-tauri/src/keystroke.rs
@@ -156,16 +156,16 @@ fn start_listening_rdev(
     thread::spawn(move || {
         if let Err(e) = rdev::listen(move |event| {
             match event.event_type {
-                rdev::EventType::KeyPress(key) => {
-                    if pressed_keys.insert(key) {
-                        let count = {
-                            let mut mc = minute_count.lock().unwrap();
-                            *mc += 1;
-                            *mc
-                        };
-                        let today_total = *today_db_count.lock().unwrap() + count;
-                        let _ = app_handle.emit("keystroke_update", today_total);
-                    }
+                rdev::EventType::KeyPress(key)
+                    if pressed_keys.insert(key) =>
+                {
+                    let count = {
+                        let mut mc = minute_count.lock().unwrap();
+                        *mc += 1;
+                        *mc
+                    };
+                    let today_total = *today_db_count.lock().unwrap() + count;
+                    let _ = app_handle.emit("keystroke_update", today_total);
                 }
                 rdev::EventType::KeyRelease(key) => {
                     pressed_keys.remove(&key);

--- a/src-tauri/src/keystroke.rs
+++ b/src-tauri/src/keystroke.rs
@@ -152,13 +152,12 @@ fn start_listening_rdev(
     let app_handle_err = app_handle.clone();
     // rdev は OS のキーリピートをフィルタしないため、長押し中も KeyPress が繰り返し届く
     // HashSet で押下中のキーを管理し、KeyPress → KeyRelease のサイクルごとに 1 カウントとする
-    let pressed_keys: Arc<Mutex<std::collections::HashSet<rdev::Key>>> =
-        Arc::new(Mutex::new(std::collections::HashSet::new()));
+    let mut pressed_keys = std::collections::HashSet::new();
     thread::spawn(move || {
         if let Err(e) = rdev::listen(move |event| {
             match event.event_type {
                 rdev::EventType::KeyPress(key) => {
-                    if pressed_keys.lock().unwrap().insert(key) {
+                    if pressed_keys.insert(key) {
                         let count = {
                             let mut mc = minute_count.lock().unwrap();
                             *mc += 1;
@@ -169,7 +168,7 @@ fn start_listening_rdev(
                     }
                 }
                 rdev::EventType::KeyRelease(key) => {
-                    pressed_keys.lock().unwrap().remove(&key);
+                    pressed_keys.remove(&key);
                 }
                 _ => {}
             }

--- a/src-tauri/src/keystroke.rs
+++ b/src-tauri/src/keystroke.rs
@@ -154,24 +154,20 @@ fn start_listening_rdev(
     // HashSet で押下中のキーを管理し、KeyPress → KeyRelease のサイクルごとに 1 カウントとする
     let mut pressed_keys = std::collections::HashSet::new();
     thread::spawn(move || {
-        if let Err(e) = rdev::listen(move |event| {
-            match event.event_type {
-                rdev::EventType::KeyPress(key)
-                    if pressed_keys.insert(key) =>
-                {
-                    let count = {
-                        let mut mc = minute_count.lock().unwrap();
-                        *mc += 1;
-                        *mc
-                    };
-                    let today_total = *today_db_count.lock().unwrap() + count;
-                    let _ = app_handle.emit("keystroke_update", today_total);
-                }
-                rdev::EventType::KeyRelease(key) => {
-                    pressed_keys.remove(&key);
-                }
-                _ => {}
+        if let Err(e) = rdev::listen(move |event| match event.event_type {
+            rdev::EventType::KeyPress(key) if pressed_keys.insert(key) => {
+                let count = {
+                    let mut mc = minute_count.lock().unwrap();
+                    *mc += 1;
+                    *mc
+                };
+                let today_total = *today_db_count.lock().unwrap() + count;
+                let _ = app_handle.emit("keystroke_update", today_total);
             }
+            rdev::EventType::KeyRelease(key) => {
+                pressed_keys.remove(&key);
+            }
+            _ => {}
         }) {
             let _ = app_handle_err.emit("listener_error", format!("{e:?}"));
         }

--- a/src-tauri/src/keystroke.rs
+++ b/src-tauri/src/keystroke.rs
@@ -20,6 +20,7 @@ extern "C" {
         callback: unsafe extern "C" fn(*mut c_void, u32, *mut c_void, *mut c_void) -> *mut c_void,
         user_info: *mut c_void,
     ) -> *mut c_void;
+    fn CGEventGetIntegerValueField(event: *mut c_void, field: u32) -> i64;
 }
 
 #[cfg(target_os = "macos")]
@@ -55,8 +56,14 @@ unsafe extern "C" fn tap_callback(
     event: *mut c_void,
     user_info: *mut c_void,
 ) -> *mut c_void {
+    // - CG_EVENT_KEY_DOWN          : CGEventType における kCGEventKeyDown の値
+    // - kCGKeyboardEventAutorepeat : 長押しで繰り返し送出されるリピートイベントを示すフィールド ID
     const CG_EVENT_KEY_DOWN: u32 = 10;
+    const KCG_KEYBOARD_EVENT_AUTOREPEAT: u32 = 8;
     if event_type == CG_EVENT_KEY_DOWN {
+        if CGEventGetIntegerValueField(event, KCG_KEYBOARD_EVENT_AUTOREPEAT) != 0 {
+            return event;
+        }
         let data = &*(user_info as *const TapUserData);
         let count = {
             let mut mc = data.minute_count.lock().unwrap();
@@ -143,16 +150,28 @@ fn start_listening_rdev(
     app_handle: tauri::AppHandle,
 ) {
     let app_handle_err = app_handle.clone();
+    // rdev は OS のキーリピートをフィルタしないため、長押し中も KeyPress が繰り返し届く
+    // HashSet で押下中のキーを管理し、KeyPress → KeyRelease のサイクルごとに 1 カウントとする
+    let pressed_keys: Arc<Mutex<std::collections::HashSet<rdev::Key>>> =
+        Arc::new(Mutex::new(std::collections::HashSet::new()));
     thread::spawn(move || {
         if let Err(e) = rdev::listen(move |event| {
-            if matches!(event.event_type, rdev::EventType::KeyPress(_)) {
-                let count = {
-                    let mut mc = minute_count.lock().unwrap();
-                    *mc += 1;
-                    *mc
-                };
-                let today_total = *today_db_count.lock().unwrap() + count;
-                let _ = app_handle.emit("keystroke_update", today_total);
+            match event.event_type {
+                rdev::EventType::KeyPress(key) => {
+                    if pressed_keys.lock().unwrap().insert(key) {
+                        let count = {
+                            let mut mc = minute_count.lock().unwrap();
+                            *mc += 1;
+                            *mc
+                        };
+                        let today_total = *today_db_count.lock().unwrap() + count;
+                        let _ = app_handle.emit("keystroke_update", today_total);
+                    }
+                }
+                rdev::EventType::KeyRelease(key) => {
+                    pressed_keys.lock().unwrap().remove(&key);
+                }
+                _ => {}
             }
         }) {
             let _ = app_handle_err.emit("listener_error", format!("{e:?}"));


### PR DESCRIPTION
close #17

### 背景

OS はキーを長押ししている間、`keydown` / `KeyPress` イベントを繰り返し送出する（キーリピート）。既存の実装はこれをフィルタしていなかったため、長押し中にカウントが増え続けていた。

### 概要

macOS・Windows/Linux それぞれでキーリピートイベントを検出し、初回押下のみカウントするよう修正した。

### 変更内容

- **macOS**: `CGEventGetIntegerValueField` で `kCGKeyboardEventAutorepeat` フィールドを確認し、値が非ゼロ（リピートイベント）の場合は早期 return でスキップ
- **Windows/Linux**: `HashSet<rdev::Key>` で押下中のキーを管理し、`KeyPress` 時は `insert()` が `true`（初回押下）の場合のみカウント。`KeyRelease` で HashSet から除去

### チェック項目

- [x] 長押ししてもカウントが 1 しか増えないこと
- [x] 通常の 1 打鍵で 1 カウントされること

### 備考

Windows・macOS の両環境で動作確認済み。