### PR TITLE
feat(about): About ウィンドウとカスタムタイトルバーを実装

### DIFF
--- a/.github/RELEASE_TEMPLATE.md
+++ b/.github/RELEASE_TEMPLATE.md
@@ -1,9 +1,9 @@
 > [!WARNING]
 > ⚠️ This is a **beta release**. Unexpected behavior may occur. If you find any issues, please report them in [Issues](https://github.com/otTATto/typemeter/issues).
 
-## ⌨️ What is Typemeter?
+## ⌨️ What is typemeter?
 
-Typemeter is a local activity meter for your typing — like a pedometer, but for your keyboard.
+typemeter is a local activity meter for your typing — like a pedometer, but for your keyboard.
 It counts your keystrokes without ever recording what you type, and all data stays on your device.
 
 ## ✨ New Features

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# Typemeter
+# typemeter
 
-Typemeter is a local activity meter for your typing, like a pedometer for your work at the keyboard.
+typemeter is a local activity meter for your typing, like a pedometer for your work at the keyboard.
 
-<img width="2059" height="986" alt="Typemeter dashboard screenshot" src="https://github.com/user-attachments/assets/30bc40a4-bde0-48d5-ba2f-725182760510" />
+<img width="2059" height="986" alt="typemeter dashboard screenshot" src="https://github.com/user-attachments/assets/30bc40a4-bde0-48d5-ba2f-725182760510" />
 
 ## Data & Privacy
 
-Typemeter records **only keystroke counts** — never the content of what you type.
+typemeter records **only keystroke counts** — never the content of what you type.
 
 - No characters or key names are stored
 - All data stays on your device (local storage only)

--- a/about.html
+++ b/about.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>About typemeter</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/about/main.ts"></script>
+  </body>
+</html>

--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,7 @@
         "@tailwindcss/vite": "^4.2.4",
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-opener": "^2",
+        "@tauri-apps/plugin-os": "^2.3.2",
         "lucide-vue-next": "^1.0.0",
         "tailwindcss": "^4.2.4",
         "vue": "^3.5.13",
@@ -307,6 +308,8 @@
     "@tauri-apps/cli-win32-x64-msvc": ["@tauri-apps/cli-win32-x64-msvc@2.11.0", "", { "os": "win32", "cpu": "x64" }, "sha512-AeDTWBd2cOZ6TX133BWsoo+LutG9o0JRcgjMsIfLE13ZugpgCMv/2dJbUiBGeRvbPOGin5A3aYmsArPVV6ZSHQ=="],
 
     "@tauri-apps/plugin-opener": ["@tauri-apps/plugin-opener@2.5.3", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-CCcUltXMOfUEArbf3db3kCE7Ggy1ExBEBl51Ko2ODJ6GDYHRp1nSNlQm5uNCFY5k7/ufaK5Ib3Du/Zir19IYQQ=="],
+
+    "@tauri-apps/plugin-os": ["@tauri-apps/plugin-os@2.3.2", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-n+nXWeuSeF9wcEsSPmRnBEGrRgOy6jjkSU+UVCOV8YUGKb2erhDOxis7IqRXiRVHhY8XMKks00BJ0OAdkpf6+A=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 

--- a/docs/releases/v0.1.0-beta.1.md
+++ b/docs/releases/v0.1.0-beta.1.md
@@ -1,9 +1,9 @@
 > [!WARNING]
 > ⚠️ This is a **beta release**. Unexpected behavior may occur. If you find any issues, please report them in [Issues](https://github.com/otTATto/typemeter/issues).
 
-## ⌨️ What is Typemeter?
+## ⌨️ What is typemeter?
 
-Typemeter is a local activity meter for your typing — like a pedometer, but for your keyboard.
+typemeter is a local activity meter for your typing — like a pedometer, but for your keyboard.
 It counts your keystrokes without ever recording what you type, and all data stays on your device.
 
 ## ✨ Features

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@tailwindcss/vite": "^4.2.4",
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-opener": "^2",
+    "@tauri-apps/plugin-os": "^2.3.2",
     "lucide-vue-next": "^1.0.0",
     "tailwindcss": "^4.2.4",
     "vue": "^3.5.13"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -463,6 +463,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1319,6 +1325,16 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2216,6 +2232,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2384,6 +2412,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.1",
  "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2488,6 +2517,22 @@ checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
 dependencies = [
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "os_info"
+version = "3.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf20a545b305cf1da722b236b5155c9bb35f1d5ceb28c048bd96ca842f41b5b"
+dependencies = [
+ "android_system_properties",
+ "log",
+ "nix",
+ "objc2",
+ "objc2-foundation",
+ "objc2-ui-kit",
+ "serde",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3488,6 +3533,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sys-locale"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eab9a99a024a169fe8a903cf9d4a3b3601109bcc13bd9e3c6fff259138626c4"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3706,6 +3760,24 @@ dependencies = [
  "url",
  "windows",
  "zbus",
+]
+
+[[package]]
+name = "tauri-plugin-os"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8f08346c8deb39e96f86973da0e2d76cbb933d7ac9b750f6dc4daf955a6f997"
+dependencies = [
+ "gethostname",
+ "log",
+ "os_info",
+ "serde",
+ "serde_json",
+ "serialize-to-javascript",
+ "sys-locale",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4181,6 +4253,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-opener",
+ "tauri-plugin-os",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -20,6 +20,7 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 tauri = { version = "2", features = [] }
 tauri-plugin-opener = "2"
+tauri-plugin-os = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 rusqlite = { version = "0.32", features = ["bundled"] }

--- a/src-tauri/capabilities/about.json
+++ b/src-tauri/capabilities/about.json
@@ -6,6 +6,7 @@
   "permissions": [
     "core:default",
     "opener:default",
+    "os:default",
     "core:window:allow-start-dragging",
     "core:window:allow-minimize",
     "core:window:allow-close"

--- a/src-tauri/capabilities/about.json
+++ b/src-tauri/capabilities/about.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "about",
+  "description": "Capability for the about window",
+  "windows": ["about"],
+  "permissions": ["core:default", "opener:default"]
+}

--- a/src-tauri/capabilities/about.json
+++ b/src-tauri/capabilities/about.json
@@ -3,5 +3,11 @@
   "identifier": "about",
   "description": "Capability for the about window",
   "windows": ["about"],
-  "permissions": ["core:default", "opener:default"]
+  "permissions": [
+    "core:default",
+    "opener:default",
+    "core:window:allow-start-dragging",
+    "core:window:allow-minimize",
+    "core:window:allow-close"
+  ]
 }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -5,6 +5,10 @@
   "windows": ["main"],
   "permissions": [
     "core:default",
-    "opener:default"
+    "opener:default",
+    "core:window:allow-start-dragging",
+    "core:window:allow-minimize",
+    "core:window:allow-toggle-maximize",
+    "core:window:allow-close"
   ]
 }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -6,6 +6,7 @@
   "permissions": [
     "core:default",
     "opener:default",
+    "os:default",
     "core:window:allow-start-dragging",
     "core:window:allow-minimize",
     "core:window:allow-toggle-maximize",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -29,9 +29,15 @@ fn get_hourly_counts(date: String, db_path: tauri::State<DbPath>) -> Vec<u64> {
 /// ここでは show・center・set_focus のみを行う。
 fn open_about_window_impl(app: &tauri::AppHandle) {
     if let Some(window) = app.get_webview_window("about") {
-        let _ = window.show();
-        let _ = window.center();
-        let _ = window.set_focus();
+        if let Err(e) = window.show() {
+            eprintln!("[typemeter] failed to show about window: {e}");
+        }
+        if let Err(e) = window.center() {
+            eprintln!("[typemeter] failed to center about window: {e}");
+        }
+        if let Err(e) = window.set_focus() {
+            eprintln!("[typemeter] failed to focus about window: {e}");
+        }
     }
 }
 
@@ -70,6 +76,7 @@ pub fn run() {
 
     let app = tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
+        .plugin(tauri_plugin_os::init())
         .setup({
             let minute_count = minute_count.clone();
             let today_db_count = today_db_count.clone();
@@ -129,10 +136,8 @@ pub fn run() {
                 // Windows/Linux: ネイティブ装飾を除去してカスタムタイトルバーに切り替え
                 #[cfg(not(target_os = "macos"))]
                 {
-                    for label in ["main", "about"] {
-                        if let Some(window) = app.get_webview_window(label) {
-                            window.set_decorations(false)?;
-                        }
+                    for window in app.webview_windows().values() {
+                        window.set_decorations(false)?;
                     }
                 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -107,15 +107,14 @@ pub fn run() {
                     flush_minute_count(&mc_save, &tdc_save, &db_path_save);
                 });
 
-                // macOS: ネイティブメニューバーに Typemeter > About Typemeter を追加
+                // macOS: ネイティブメニューバーに typemeter > About typemeter を追加
                 #[cfg(target_os = "macos")]
                 {
                     use tauri::menu::{MenuBuilder, MenuItemBuilder, SubmenuBuilder};
-                    let about_item =
-                        MenuItemBuilder::with_id("about_typemeter", "About Typemeter")
-                            .build(app)?;
+                    let about_item = MenuItemBuilder::with_id("about_typemeter", "About typemeter")
+                        .build(app)?;
                     let about_id = about_item.id().clone();
-                    let typemeter_submenu = SubmenuBuilder::new(app, "Typemeter")
+                    let typemeter_submenu = SubmenuBuilder::new(app, "typemeter")
                         .item(&about_item)
                         .build()?;
                     let menu = MenuBuilder::new(app).item(&typemeter_submenu).build()?;
@@ -145,7 +144,10 @@ pub fn run() {
                 Ok(())
             }
         })
-        .invoke_handler(tauri::generate_handler![get_hourly_counts, open_about_window])
+        .invoke_handler(tauri::generate_handler![
+            get_hourly_counts,
+            open_about_window
+        ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application");
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -130,8 +130,10 @@ pub fn run() {
                 // Windows/Linux: ネイティブ装飾を除去してカスタムタイトルバーに切り替え
                 #[cfg(not(target_os = "macos"))]
                 {
-                    if let Some(window) = app.get_webview_window("main") {
-                        window.set_decorations(false)?;
+                    for label in ["main", "about"] {
+                        if let Some(window) = app.get_webview_window(label) {
+                            window.set_decorations(false)?;
+                        }
                     }
                 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -22,6 +22,25 @@ fn get_hourly_counts(date: String, db_path: tauri::State<DbPath>) -> Vec<u64> {
     query_hourly_counts(&db_path.0, &date).to_vec()
 }
 
+/// About ウィンドウを表示する。既に表示中の場合はフォーカスする
+///
+/// # Behavior
+/// About ウィンドウは起動時に `visible: false` で生成済みのため、
+/// ここでは show・center・set_focus のみを行う。
+fn open_about_window_impl(app: &tauri::AppHandle) {
+    if let Some(window) = app.get_webview_window("about") {
+        let _ = window.show();
+        let _ = window.center();
+        let _ = window.set_focus();
+    }
+}
+
+/// About ウィンドウを開く Tauri コマンド（Windows/Linux のカスタムメニューから呼び出される）
+#[tauri::command]
+fn open_about_window(app: tauri::AppHandle) {
+    open_about_window_impl(&app);
+}
+
 fn resolve_db_path(app: &tauri::App) -> String {
     if let Some(path) = std::env::var("TYPEMETER_DB_PATH")
         .ok()
@@ -88,10 +107,43 @@ pub fn run() {
                     flush_minute_count(&mc_save, &tdc_save, &db_path_save);
                 });
 
+                // macOS: ネイティブメニューバーに Typemeter > About Typemeter を追加
+                #[cfg(target_os = "macos")]
+                {
+                    use tauri::menu::{MenuBuilder, MenuItemBuilder, SubmenuBuilder};
+                    let about_item =
+                        MenuItemBuilder::with_id("about_typemeter", "About Typemeter")
+                            .build(app)?;
+                    let about_id = about_item.id().clone();
+                    let typemeter_submenu = SubmenuBuilder::new(app, "Typemeter")
+                        .item(&about_item)
+                        .build()?;
+                    let menu = MenuBuilder::new(app).item(&typemeter_submenu).build()?;
+                    app.set_menu(menu)?;
+                    app.on_menu_event(move |app_handle, event| {
+                        if event.id() == &about_id {
+                            open_about_window_impl(app_handle);
+                        }
+                    });
+                }
+
+                // Windows/Linux: ネイティブ装飾を除去してカスタムタイトルバーに切り替え
+                #[cfg(not(target_os = "macos"))]
+                {
+                    if let Some(window) = app.get_webview_window("main") {
+                        window.set_decorations(false)?;
+                    }
+                }
+
+                // visible: false で起動しているためここで表示する（装飾変更後に表示することでちらつきを防ぐ）
+                if let Some(window) = app.get_webview_window("main") {
+                    window.show()?;
+                }
+
                 Ok(())
             }
         })
-        .invoke_handler(tauri::generate_handler![get_hourly_counts])
+        .invoke_handler(tauri::generate_handler![get_hourly_counts, open_about_window])
         .build(tauri::generate_context!())
         .expect("error while building tauri application");
 
@@ -105,11 +157,22 @@ pub fn run() {
                 );
             }
             // macOS では赤×でウィンドウを閉じてもプロセスが残り Exit が来ないため、
-            // CloseRequested で明示的に終了する
+            // CloseRequested で明示的に終了する（About などのサブウィンドウは対象外）
             tauri::RunEvent::WindowEvent {
+                label,
+                event: tauri::WindowEvent::CloseRequested { api, .. },
+                ..
+            } if label == "about" => {
+                api.prevent_close();
+                if let Some(window) = app_handle.get_webview_window("about") {
+                    let _ = window.hide();
+                }
+            }
+            tauri::RunEvent::WindowEvent {
+                label,
                 event: tauri::WindowEvent::CloseRequested { .. },
                 ..
-            } => {
+            } if label == "main" => {
                 app_handle.exit(0);
             }
             tauri::RunEvent::Exit => {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -16,7 +16,18 @@
         "width": 1000,
         "height": 870,
         "minWidth": 680,
-        "minHeight": 200
+        "minHeight": 200,
+        "visible": false
+      },
+      {
+        "label": "about",
+        "title": "About Typemeter",
+        "url": "about.html",
+        "width": 480,
+        "height": 400,
+        "resizable": false,
+        "visible": false,
+        "center": true
       }
     ],
     "security": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -21,7 +21,7 @@
       },
       {
         "label": "about",
-        "title": "About Typemeter",
+        "title": "About typemeter",
         "url": "about.html",
         "width": 480,
         "height": 400,

--- a/src/App.vue
+++ b/src/App.vue
@@ -89,7 +89,7 @@ const SHOW_TITLE_BAR = !navigator.userAgent.includes('Macintosh');
     <!-- Error overlay -->
     <template v-if="listenerError">
       <div class="flex flex-col items-center justify-center h-screen gap-2">
-        <p class="text-base text-[#e53e3e] m-0">Failed to start capturing keystrokes.</p>
+        <p class="text-base text-danger-color m-0">Failed to start capturing keystrokes.</p>
         <p class="text-xs opacity-60 m-0 font-mono">{{ listenerError }}</p>
       </div>
     </template>

--- a/src/App.vue
+++ b/src/App.vue
@@ -5,6 +5,7 @@ import DayStamps from '@/components/DayStamps.vue';
 import MeterRing from '@/components/MeterRing.vue';
 import TabGroup from '@/components/TabGroup.vue';
 import ThemeToggle from '@/components/ThemeToggle.vue';
+import TitleBar from '@/components/TitleBar.vue';
 import { formatDate } from '@/lib/date';
 import {
   fetchHourlyCounts,
@@ -75,10 +76,15 @@ const displayChars = computed(() =>
 );
 
 const DAILY_GOAL = 10000;
+
+// macOS はネイティブメニューバーを使うため、Windows/Linux のみカスタムタイトルバーを表示する
+const SHOW_TITLE_BAR = !navigator.userAgent.includes('Macintosh');
 </script>
 
 <template>
   <div class="flex flex-col h-screen bg-background-color">
+    <TitleBar v-if="SHOW_TITLE_BAR" />
+
     <!-- Error overlay -->
     <template v-if="listenerError">
       <div class="flex flex-col items-center justify-center h-screen gap-2">

--- a/src/App.vue
+++ b/src/App.vue
@@ -95,7 +95,7 @@ const SHOW_TITLE_BAR = !navigator.userAgent.includes('Macintosh');
     </template>
 
     <template v-else>
-      <TitleBarOffset v-if="SHOW_TITLE_BAR" />
+      <TitleBarOffset :has-title-bar="SHOW_TITLE_BAR" />
 
       <!-- Header -->
       <header class="flex items-center px-6 h-22 shrink-0">

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { platform } from '@tauri-apps/plugin-os';
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue';
 import DayNav from '@/components/DayNav.vue';
 import DayStamps from '@/components/DayStamps.vue';
@@ -26,7 +27,12 @@ const listenerError = ref<string | null>(null);
 
 const unlisteners: Array<() => void> = [];
 
+// macOS はネイティブメニューバーを使うため、Windows/Linux のみカスタムタイトルバーを表示する
+// UA による初期値で初回レンダリングのちらつきを防ぎ、plugin-os で確定する
+const showTitleBar = ref(!navigator.userAgent.includes('Macintosh'));
+
 onMounted(async () => {
+  showTitleBar.value = (await platform()) !== 'macos';
   unlisteners.push(
     await subscribeKeystrokeUpdate((total) => {
       todayTotal.value = total;
@@ -77,14 +83,11 @@ const displayChars = computed(() =>
 );
 
 const DAILY_GOAL = 10000;
-
-// macOS はネイティブメニューバーを使うため、Windows/Linux のみカスタムタイトルバーを表示する
-const SHOW_TITLE_BAR = !navigator.userAgent.includes('Macintosh');
 </script>
 
 <template>
   <div class="flex flex-col h-screen bg-background-color">
-    <TitleBar v-if="SHOW_TITLE_BAR" />
+    <TitleBar v-if="showTitleBar" />
 
     <!-- Error overlay -->
     <template v-if="listenerError">
@@ -95,7 +98,7 @@ const SHOW_TITLE_BAR = !navigator.userAgent.includes('Macintosh');
     </template>
 
     <template v-else>
-      <TitleBarOffset :has-title-bar="SHOW_TITLE_BAR" />
+      <TitleBarOffset :has-title-bar="showTitleBar" />
 
       <!-- Header -->
       <header class="flex items-center px-6 h-22 shrink-0">

--- a/src/App.vue
+++ b/src/App.vue
@@ -6,6 +6,7 @@ import MeterRing from '@/components/MeterRing.vue';
 import TabGroup from '@/components/TabGroup.vue';
 import ThemeToggle from '@/components/ThemeToggle.vue';
 import TitleBar from '@/components/TitleBar.vue';
+import TitleBarOffset from '@/components/TitleBarOffset.vue';
 import { formatDate } from '@/lib/date';
 import {
   fetchHourlyCounts,
@@ -94,6 +95,8 @@ const SHOW_TITLE_BAR = !navigator.userAgent.includes('Macintosh');
     </template>
 
     <template v-else>
+      <TitleBarOffset v-if="SHOW_TITLE_BAR" />
+
       <!-- Header -->
       <header class="flex items-center px-6 h-22 shrink-0">
         <div class="flex-1"><TabGroup /></div>

--- a/src/about/App.vue
+++ b/src/about/App.vue
@@ -49,7 +49,7 @@ const SHOW_TITLE_BAR = !navigator.userAgent.includes('Macintosh');
       :show-maximize="false"
       title="About typemeter"
     />
-    <TitleBarOffset v-if="SHOW_TITLE_BAR" />
+    <TitleBarOffset :has-title-bar="SHOW_TITLE_BAR" />
 
     <div class="flex flex-col justify-center flex-1 px-8 py-6 overflow-y-auto">
       <!-- アプリ名とバージョン -->

--- a/src/about/App.vue
+++ b/src/about/App.vue
@@ -2,6 +2,8 @@
 import { getVersion } from '@tauri-apps/api/app';
 import { openUrl } from '@tauri-apps/plugin-opener';
 import { onMounted, ref } from 'vue';
+import TitleBar from '@/components/TitleBar.vue';
+import TitleBarOffset from '@/components/TitleBarOffset.vue';
 
 const version = ref('');
 
@@ -20,41 +22,69 @@ onMounted(async () => {
   }
 });
 
+const openRelease = (version: string) =>
+  openUrl(`https://github.com/otTATto/typemeter/releases/tag/v${version}`);
+const openX = () => openUrl('https://x.com/0123tato');
 const openGitHub = () => openUrl('https://github.com/otTATto/typemeter');
+
+// macOS はネイティブメニューバーを使うため、Windows/Linux のみカスタムタイトルバーを表示する
+const SHOW_TITLE_BAR = !navigator.userAgent.includes('Macintosh');
 </script>
 
 <template>
-  <div
-    class="flex flex-col justify-center h-screen bg-background-color px-8 py-6 select-none overflow-y-auto"
-  >
-    <!-- アプリ名とバージョン -->
-    <div class="flex flex-col items-center gap-1.5 mb-6">
-      <h1 class="text-4xl font-bold text-base-color tracking-tight">typemeter</h1>
-      <p v-if="version" class="text-sm text-sub-color">Version {{ version }}</p>
-    </div>
+  <div class="flex flex-col h-screen bg-background-color select-none">
+    <TitleBar
+      v-if="SHOW_TITLE_BAR"
+      :show-menu="false"
+      :show-maximize="false"
+      title="About typemeter"
+    />
+    <TitleBarOffset v-if="SHOW_TITLE_BAR" />
 
-    <!-- コピーライトと GitHub リンク -->
-    <div class="flex flex-col items-center gap-2 mb-6">
-      <p class="text-sm text-base-color">© 2026 otTATto</p>
-      <button
-        class="text-sm text-accent-color hover:underline cursor-pointer bg-transparent border-0 p-0"
-        @click="openGitHub"
-      >
-        github.com/otTATto/typemeter
-      </button>
-    </div>
+    <div class="flex flex-col justify-center flex-1 px-8 py-6 overflow-y-auto">
+      <!-- アプリ名とバージョン -->
+      <div class="flex flex-col items-center gap-1.5 mb-6">
+        <h1 class="text-4xl font-bold text-base-color tracking-tight">typemeter</h1>
+        <button
+          v-if="version"
+          class="text-sm text-sub-color hover:underline cursor-pointer bg-transparent border-0 p-0"
+          @click="openRelease(version)"
+        >
+          v{{ version }}
+        </button>
+      </div>
 
-    <hr class="border-sub-color/30 mb-5" />
+      <!-- コピーライトと GitHub リンク -->
+      <div class="flex flex-col items-center gap-2 mb-6">
+        <p class="text-sm text-base-color">
+          © 2026
+          <button
+            class="text-sm text-base-color hover:underline cursor-pointer bg-transparent border-0 p-0"
+            @click="openX"
+          >
+            tato
+          </button>
+        </p>
+        <button
+          class="text-sm text-accent-color hover:underline cursor-pointer bg-transparent border-0 p-0"
+          @click="openGitHub"
+        >
+          github.com/otTATto/typemeter
+        </button>
+      </div>
 
-    <!-- オープンソースライセンス -->
-    <div>
-      <h2 class="text-xs font-bold text-sub-color uppercase tracking-wider mb-3">
-        Open Source Licenses
-      </h2>
-      <div class="space-y-1 text-xs text-sub-color">
-        <p class="font-medium text-base-color">Manjari (Latin Subset)</p>
-        <p>Copyright 2018 The Manjari Project Authors</p>
-        <p>Licensed under the SIL Open Font License, Version 1.1.</p>
+      <hr class="border-sub-color/30 mb-5" />
+
+      <!-- オープンソースライセンス -->
+      <div>
+        <h2 class="text-xs font-bold text-sub-color uppercase tracking-wider mb-3">
+          Open Source Licenses
+        </h2>
+        <div class="space-y-1 text-xs text-sub-color">
+          <p class="font-medium text-base-color">Manjari (Latin Subset)</p>
+          <p>Copyright 2018 The Manjari Project Authors</p>
+          <p>Licensed under the SIL Open Font License, Version 1.1.</p>
+        </div>
       </div>
     </div>
   </div>

--- a/src/about/App.vue
+++ b/src/about/App.vue
@@ -24,7 +24,9 @@ const openGitHub = () => openUrl('https://github.com/otTATto/typemeter');
 </script>
 
 <template>
-  <div class="flex flex-col h-screen bg-background-color px-8 pt-8 pb-6 select-none">
+  <div
+    class="flex flex-col justify-center h-screen bg-background-color px-8 py-6 select-none overflow-y-auto"
+  >
     <!-- アプリ名とバージョン -->
     <div class="flex flex-col items-center gap-1.5 mb-6">
       <h1 class="text-4xl font-bold text-base-color tracking-tight">typemeter</h1>
@@ -45,7 +47,7 @@ const openGitHub = () => openUrl('https://github.com/otTATto/typemeter');
     <hr class="border-sub-color/30 mb-5" />
 
     <!-- オープンソースライセンス -->
-    <div class="flex-1 overflow-y-auto">
+    <div>
       <h2 class="text-xs font-bold text-sub-color uppercase tracking-wider mb-3">
         Open Source Licenses
       </h2>

--- a/src/about/App.vue
+++ b/src/about/App.vue
@@ -1,25 +1,23 @@
 <script setup lang="ts">
 import { getVersion } from '@tauri-apps/api/app';
 import { openUrl } from '@tauri-apps/plugin-opener';
+import { platform } from '@tauri-apps/plugin-os';
 import { onMounted, onUnmounted, ref } from 'vue';
 import TitleBar from '@/components/TitleBar.vue';
 import TitleBarOffset from '@/components/TitleBarOffset.vue';
+import { initTheme } from '@/lib/theme';
 
 const version = ref('');
 
-const applyTheme = () => {
-  const saved = localStorage.getItem('theme');
-  const isDark =
-    saved === 'dark' || saved === 'light'
-      ? saved === 'dark'
-      : window.matchMedia('(prefers-color-scheme: dark)').matches;
-  document.documentElement.classList.toggle('dark', isDark);
-};
+// macOS はネイティブメニューバーを使うため、Windows/Linux のみカスタムタイトルバーを表示する
+// UA による初期値で初回レンダリングのちらつきを防ぎ、plugin-os で確定する
+const showTitleBar = ref(!navigator.userAgent.includes('Macintosh'));
+
+let cleanupTheme: (() => void) | null = null;
 
 onMounted(async () => {
-  applyTheme();
-  // storage イベントは他ウィンドウの localStorage 変更時に発火する
-  window.addEventListener('storage', applyTheme);
+  cleanupTheme = initTheme();
+  showTitleBar.value = (await platform()) !== 'macos';
 
   try {
     version.value = await getVersion();
@@ -29,27 +27,24 @@ onMounted(async () => {
 });
 
 onUnmounted(() => {
-  window.removeEventListener('storage', applyTheme);
+  cleanupTheme?.();
 });
 
 const openRelease = (version: string) =>
   openUrl(`https://github.com/otTATto/typemeter/releases/tag/v${version}`);
 const openX = () => openUrl('https://x.com/0123tato');
 const openGitHub = () => openUrl('https://github.com/otTATto/typemeter');
-
-// macOS はネイティブメニューバーを使うため、Windows/Linux のみカスタムタイトルバーを表示する
-const SHOW_TITLE_BAR = !navigator.userAgent.includes('Macintosh');
 </script>
 
 <template>
   <div class="flex flex-col h-screen bg-background-color select-none">
     <TitleBar
-      v-if="SHOW_TITLE_BAR"
+      v-if="showTitleBar"
       :show-menu="false"
       :show-maximize="false"
       title="About typemeter"
     />
-    <TitleBarOffset :has-title-bar="SHOW_TITLE_BAR" />
+    <TitleBarOffset :has-title-bar="showTitleBar" />
 
     <div class="flex flex-col justify-center flex-1 px-8 py-6 overflow-y-auto">
       <!-- アプリ名とバージョン -->

--- a/src/about/App.vue
+++ b/src/about/App.vue
@@ -1,25 +1,35 @@
 <script setup lang="ts">
 import { getVersion } from '@tauri-apps/api/app';
 import { openUrl } from '@tauri-apps/plugin-opener';
-import { onMounted, ref } from 'vue';
+import { onMounted, onUnmounted, ref } from 'vue';
 import TitleBar from '@/components/TitleBar.vue';
 import TitleBarOffset from '@/components/TitleBarOffset.vue';
 
 const version = ref('');
 
-onMounted(async () => {
+const applyTheme = () => {
   const saved = localStorage.getItem('theme');
   const isDark =
     saved === 'dark' || saved === 'light'
       ? saved === 'dark'
       : window.matchMedia('(prefers-color-scheme: dark)').matches;
   document.documentElement.classList.toggle('dark', isDark);
+};
+
+onMounted(async () => {
+  applyTheme();
+  // storage イベントは他ウィンドウの localStorage 変更時に発火する
+  window.addEventListener('storage', applyTheme);
 
   try {
     version.value = await getVersion();
   } catch {
     // version は空文字のまま表示しない
   }
+});
+
+onUnmounted(() => {
+  window.removeEventListener('storage', applyTheme);
 });
 
 const openRelease = (version: string) =>

--- a/src/about/App.vue
+++ b/src/about/App.vue
@@ -1,0 +1,59 @@
+<script setup lang="ts">
+import { getVersion } from '@tauri-apps/api/app';
+import { openUrl } from '@tauri-apps/plugin-opener';
+import { onMounted, ref } from 'vue';
+
+const version = ref('');
+
+onMounted(async () => {
+  const saved = localStorage.getItem('theme');
+  const isDark =
+    saved === 'dark' || saved === 'light'
+      ? saved === 'dark'
+      : window.matchMedia('(prefers-color-scheme: dark)').matches;
+  document.documentElement.classList.toggle('dark', isDark);
+
+  try {
+    version.value = await getVersion();
+  } catch {
+    // version は空文字のまま表示しない
+  }
+});
+
+const openGitHub = () => openUrl('https://github.com/otTATto/typemeter');
+</script>
+
+<template>
+  <div class="flex flex-col h-screen bg-background-color px-8 pt-8 pb-6 select-none">
+    <!-- アプリ名とバージョン -->
+    <div class="flex flex-col items-center gap-1.5 mb-6">
+      <h1 class="text-4xl font-bold text-base-color tracking-tight">typemeter</h1>
+      <p v-if="version" class="text-sm text-sub-color">Version {{ version }}</p>
+    </div>
+
+    <!-- コピーライトと GitHub リンク -->
+    <div class="flex flex-col items-center gap-2 mb-6">
+      <p class="text-sm text-base-color">© 2026 otTATto</p>
+      <button
+        class="text-sm text-accent-color hover:underline cursor-pointer bg-transparent border-0 p-0"
+        @click="openGitHub"
+      >
+        github.com/otTATto/typemeter
+      </button>
+    </div>
+
+    <hr class="border-sub-color/30 mb-5" />
+
+    <!-- オープンソースライセンス -->
+    <div class="flex-1 overflow-y-auto">
+      <h2 class="text-xs font-bold text-sub-color uppercase tracking-wider mb-3">
+        Open Source Licenses
+      </h2>
+      <div class="space-y-1 text-xs text-sub-color">
+        <p class="font-medium text-base-color">Manjari (Latin Subset)</p>
+        <p>Copyright 2018 The Manjari Project Authors</p>
+        <p>Licensed under the SIL Open Font License, Version 1.1.</p>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/about/main.ts
+++ b/src/about/main.ts
@@ -1,0 +1,5 @@
+import { createApp } from 'vue';
+import '@/style.css';
+import App from './App.vue';
+
+createApp(App).mount('#app');

--- a/src/components/TitleBar.vue
+++ b/src/components/TitleBar.vue
@@ -6,6 +6,16 @@ import { getCurrentWindow } from '@tauri-apps/api/window';
 import { Maximize2, Minimize2, Minus, X } from 'lucide-vue-next';
 import { onMounted, onUnmounted, ref } from 'vue';
 
+/**
+ * - showMenu     : 左側の「typemeter」メニューを表示するか（デフォルト: true）
+ * - showMaximize : 最大化/最小化ボタンを表示するか（デフォルト: true）
+ * - title        : タイトルバー中央に表示するウィンドウ名（省略時は非表示）
+ */
+const props = withDefaults(
+  defineProps<{ showMenu?: boolean; showMaximize?: boolean; title?: string }>(),
+  { showMenu: true, showMaximize: true },
+);
+
 const appWindow = getCurrentWindow();
 const isMenuOpen = ref(false);
 const isMaximized = ref(false);
@@ -13,10 +23,12 @@ const isMaximized = ref(false);
 let unlistenResize: (() => void) | null = null;
 
 onMounted(async () => {
-  isMaximized.value = await appWindow.isMaximized();
-  unlistenResize = await appWindow.onResized(async () => {
+  if (props.showMaximize) {
     isMaximized.value = await appWindow.isMaximized();
-  });
+    unlistenResize = await appWindow.onResized(async () => {
+      isMaximized.value = await appWindow.isMaximized();
+    });
+  }
   document.addEventListener('click', closeMenu);
 });
 
@@ -46,44 +58,58 @@ const close = () => appWindow.close();
 <template>
   <div
     data-tauri-drag-region
-    class="flex items-center justify-between w-full h-11 bg-pond-color select-none shrink-0"
+    class="relative flex items-center justify-between w-full h-11 bg-bg-color select-none shrink-0"
   >
     <!-- 左：Typemeter メニュー -->
     <div class="relative h-full flex items-center">
-      <button
-        class="h-full px-4 text-sm text-base-color hover:bg-sub-color/20 transition-colors cursor-default"
-        @click.stop="toggleMenu"
-      >
-        Typemeter
-      </button>
-      <Transition name="dropdown-fade">
-        <div
-          v-if="isMenuOpen"
-          class="absolute top-full left-0 bg-pond-color border border-sub-color/20 shadow-lg rounded py-1 min-w-40 z-50"
-          @click.stop
+      <template v-if="showMenu">
+        <button
+          :class="[
+            'h-full px-4 text-sm text-base-color hover:bg-sub-color/20 transition-colors cursor-pointer',
+            isMenuOpen ? 'bg-sub-color/20' : '',
+          ]"
+          @click.stop="toggleMenu"
         >
-          <button
-            class="w-full text-left px-4 py-2 text-sm text-base-color hover:bg-sub-color/20 transition-colors cursor-default"
-            @click="openAbout"
+          typemeter
+        </button>
+        <Transition name="dropdown-fade">
+          <div
+            v-if="isMenuOpen"
+            class="absolute top-full left-0 bg-pond-color border border-sub-color/20 shadow-lg rounded-2xl p-1 min-w-40 z-50"
+            @click.stop
           >
-            About Typemeter
-          </button>
-        </div>
-      </Transition>
+            <button
+              class="w-full text-left px-4 py-2 text-sm text-base-color hover:bg-sub-color/20 rounded-2xl transition-colors cursor-pointer"
+              @click="openAbout"
+            >
+              About typemeter
+            </button>
+          </div>
+        </Transition>
+      </template>
     </div>
+
+    <!-- 中央：ウィンドウタイトル -->
+    <span
+      v-if="title"
+      class="absolute left-1/2 -translate-x-1/2 text-sm text-base-color pointer-events-none"
+    >
+      {{ title }}
+    </span>
 
     <!-- 右：ウィンドウ操作ボタン -->
     <div class="flex h-full">
       <button
         aria-label="最小化"
-        class="flex items-center justify-center w-11 h-full text-base-color hover:bg-sub-color/20 transition-colors cursor-default"
+        class="flex items-center justify-center w-11 h-full text-base-color hover:bg-sub-color/20 transition-colors cursor-pointer"
         @click="minimize"
       >
         <Minus :size="12" />
       </button>
       <button
+        v-if="showMaximize"
         aria-label="最大化を切り替え"
-        class="flex items-center justify-center w-11 h-full text-base-color hover:bg-sub-color/20 transition-colors cursor-default"
+        class="flex items-center justify-center w-11 h-full text-base-color hover:bg-sub-color/20 transition-colors cursor-pointer"
         @click="toggleMaximize"
       >
         <Maximize2 v-if="!isMaximized" :size="12" />
@@ -91,7 +117,7 @@ const close = () => appWindow.close();
       </button>
       <button
         aria-label="閉じる"
-        class="close-btn flex items-center justify-center w-11 h-full text-base-color transition-colors cursor-default"
+        class="flex items-center justify-center w-11 h-full text-base-color hover:bg-danger-color hover:text-tm-white transition-colors cursor-pointer"
         @click="close"
       >
         <X :size="12" />
@@ -101,11 +127,6 @@ const close = () => appWindow.close();
 </template>
 
 <style scoped>
-.close-btn:hover {
-  background-color: #c42b1c;
-  color: white;
-}
-
 .dropdown-fade-enter-active,
 .dropdown-fade-leave-active {
   transition: opacity 0.1s ease;

--- a/src/components/TitleBar.vue
+++ b/src/components/TitleBar.vue
@@ -20,20 +20,22 @@ const appWindow = getCurrentWindow();
 const isMenuOpen = ref(false);
 const isMaximized = ref(false);
 
-let unlistenResize: (() => void) | null = null;
+let unlistenResize: Promise<() => void> | null = null;
 
-onMounted(async () => {
+onMounted(() => {
   if (props.showMaximize) {
-    isMaximized.value = await appWindow.isMaximized();
-    unlistenResize = await appWindow.onResized(async () => {
+    unlistenResize = (async () => {
       isMaximized.value = await appWindow.isMaximized();
-    });
+      return appWindow.onResized(async () => {
+        isMaximized.value = await appWindow.isMaximized();
+      });
+    })();
   }
   document.addEventListener('click', closeMenu);
 });
 
-onUnmounted(() => {
-  unlistenResize?.();
+onUnmounted(async () => {
+  (await unlistenResize)?.();
   document.removeEventListener('click', closeMenu);
 });
 
@@ -58,12 +60,14 @@ const close = () => appWindow.close();
 <template>
   <div
     data-tauri-drag-region
-    class="relative flex items-center justify-between w-full h-11 bg-bg-color select-none shrink-0"
+    class="relative flex items-center justify-between w-full h-11 bg-background-color select-none shrink-0"
   >
     <!-- 左：Typemeter メニュー -->
     <div class="relative h-full flex items-center">
       <template v-if="showMenu">
         <button
+          aria-haspopup="true"
+          :aria-expanded="isMenuOpen"
           :class="[
             'h-full px-4 text-sm text-base-color hover:bg-sub-color/20 transition-colors cursor-pointer',
             isMenuOpen ? 'bg-sub-color/20' : '',
@@ -100,7 +104,7 @@ const close = () => appWindow.close();
     <!-- 右：ウィンドウ操作ボタン -->
     <div class="flex h-full">
       <button
-        aria-label="最小化"
+        aria-label="Minimize"
         class="flex items-center justify-center w-11 h-full text-base-color hover:bg-sub-color/20 transition-colors cursor-pointer"
         @click="minimize"
       >
@@ -108,7 +112,7 @@ const close = () => appWindow.close();
       </button>
       <button
         v-if="showMaximize"
-        aria-label="最大化を切り替え"
+        aria-label="Toggle maximize"
         class="flex items-center justify-center w-11 h-full text-base-color hover:bg-sub-color/20 transition-colors cursor-pointer"
         @click="toggleMaximize"
       >
@@ -116,7 +120,7 @@ const close = () => appWindow.close();
         <Minimize2 v-else :size="12" />
       </button>
       <button
-        aria-label="閉じる"
+        aria-label="Close"
         class="flex items-center justify-center w-11 h-full text-base-color hover:bg-danger-color hover:text-tm-white transition-colors cursor-pointer"
         @click="close"
       >

--- a/src/components/TitleBar.vue
+++ b/src/components/TitleBar.vue
@@ -1,0 +1,118 @@
+<!-- Windows/Linux 向けカスタムタイトルバー -->
+<!-- decorations: false のウィンドウで使用する -->
+<script setup lang="ts">
+import { invoke } from '@tauri-apps/api/core';
+import { getCurrentWindow } from '@tauri-apps/api/window';
+import { Maximize2, Minimize2, Minus, X } from 'lucide-vue-next';
+import { onMounted, onUnmounted, ref } from 'vue';
+
+const appWindow = getCurrentWindow();
+const isMenuOpen = ref(false);
+const isMaximized = ref(false);
+
+let unlistenResize: (() => void) | null = null;
+
+onMounted(async () => {
+  isMaximized.value = await appWindow.isMaximized();
+  unlistenResize = await appWindow.onResized(async () => {
+    isMaximized.value = await appWindow.isMaximized();
+  });
+  document.addEventListener('click', closeMenu);
+});
+
+onUnmounted(() => {
+  unlistenResize?.();
+  document.removeEventListener('click', closeMenu);
+});
+
+const toggleMenu = () => {
+  isMenuOpen.value = !isMenuOpen.value;
+};
+
+const closeMenu = () => {
+  isMenuOpen.value = false;
+};
+
+const openAbout = async () => {
+  closeMenu();
+  await invoke('open_about_window');
+};
+
+const minimize = () => appWindow.minimize();
+const toggleMaximize = () => appWindow.toggleMaximize();
+const close = () => appWindow.close();
+</script>
+
+<template>
+  <div
+    data-tauri-drag-region
+    class="flex items-center justify-between w-full h-11 bg-pond-color select-none shrink-0"
+  >
+    <!-- 左：Typemeter メニュー -->
+    <div class="relative h-full flex items-center">
+      <button
+        class="h-full px-4 text-sm text-base-color hover:bg-sub-color/20 transition-colors cursor-default"
+        @click.stop="toggleMenu"
+      >
+        Typemeter
+      </button>
+      <Transition name="dropdown-fade">
+        <div
+          v-if="isMenuOpen"
+          class="absolute top-full left-0 bg-pond-color border border-sub-color/20 shadow-lg rounded py-1 min-w-40 z-50"
+          @click.stop
+        >
+          <button
+            class="w-full text-left px-4 py-2 text-sm text-base-color hover:bg-sub-color/20 transition-colors cursor-default"
+            @click="openAbout"
+          >
+            About Typemeter
+          </button>
+        </div>
+      </Transition>
+    </div>
+
+    <!-- 右：ウィンドウ操作ボタン -->
+    <div class="flex h-full">
+      <button
+        aria-label="最小化"
+        class="flex items-center justify-center w-11 h-full text-base-color hover:bg-sub-color/20 transition-colors cursor-default"
+        @click="minimize"
+      >
+        <Minus :size="12" />
+      </button>
+      <button
+        aria-label="最大化を切り替え"
+        class="flex items-center justify-center w-11 h-full text-base-color hover:bg-sub-color/20 transition-colors cursor-default"
+        @click="toggleMaximize"
+      >
+        <Maximize2 v-if="!isMaximized" :size="12" />
+        <Minimize2 v-else :size="12" />
+      </button>
+      <button
+        aria-label="閉じる"
+        class="close-btn flex items-center justify-center w-11 h-full text-base-color transition-colors cursor-default"
+        @click="close"
+      >
+        <X :size="12" />
+      </button>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.close-btn:hover {
+  background-color: #c42b1c;
+  color: white;
+}
+
+.dropdown-fade-enter-active,
+.dropdown-fade-leave-active {
+  transition: opacity 0.1s ease;
+}
+
+.dropdown-fade-enter-from,
+.dropdown-fade-leave-to {
+  opacity: 0;
+}
+</style>

--- a/src/components/TitleBarOffset.vue
+++ b/src/components/TitleBarOffset.vue
@@ -1,0 +1,5 @@
+<!-- カスタムタイトルバー分の上部余白を縮めるスペーサー -->
+<!-- TitleBar の直後に v-if="SHOW_TITLE_BAR" で配置する -->
+<template>
+  <div class="-mb-4"></div>
+</template>

--- a/src/components/TitleBarOffset.vue
+++ b/src/components/TitleBarOffset.vue
@@ -1,5 +1,13 @@
-<!-- カスタムタイトルバー分の上部余白を縮めるスペーサー -->
-<!-- TitleBar の直後に v-if="SHOW_TITLE_BAR" で配置する -->
+<!-- カスタムタイトルバー表示有無に応じて直後の要素との上部余白を補正するスペーサー -->
+<script setup lang="ts">
+/**
+ * - hasTitleBar : カスタムタイトルバーが表示されているか（デフォルト: true）
+ *                 Windows/Linux でカスタムタイトルバーを使う場合は true（-mb-4）、
+ *                 macOS でネイティブメニューバーを使う場合は false（-mb-2）
+ */
+withDefaults(defineProps<{ hasTitleBar?: boolean }>(), { hasTitleBar: true });
+</script>
+
 <template>
-  <div class="-mb-4"></div>
+  <div :class="hasTitleBar ? '-mb-4' : '-mb-2'"></div>
 </template>

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,0 +1,26 @@
+const applyTheme = () => {
+  const saved = localStorage.getItem('theme');
+  const isDark =
+    saved === 'dark' || saved === 'light'
+      ? saved === 'dark'
+      : window.matchMedia('(prefers-color-scheme: dark)').matches;
+  document.documentElement.classList.toggle('dark', isDark);
+};
+
+/**
+ * @function テーマを初期適用し、ストレージ変更とシステムテーマ変更を監視する
+ *
+ * @returns クリーンアップ関数（onUnmounted で呼び出す）
+ */
+export const initTheme = (): (() => void) => {
+  applyTheme();
+
+  const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+  window.addEventListener('storage', applyTheme);
+  mediaQuery.addEventListener('change', applyTheme);
+
+  return () => {
+    window.removeEventListener('storage', applyTheme);
+    mediaQuery.removeEventListener('change', applyTheme);
+  };
+};

--- a/src/style.css
+++ b/src/style.css
@@ -9,6 +9,7 @@
   --color-tm-dark-black: oklch(40% 0.0098 73deg);
   --color-tm-black: oklch(35% 0.01 80deg);
   --color-tm-green: oklch(80% 0.05 170deg);
+  --color-tm-red: oklch(60% 0.15 15deg);
 }
 
 @font-face {
@@ -36,6 +37,7 @@
   --color-sub-color: var(--sub-color);
   --color-base-color: var(--base-color);
   --color-accent-color: var(--accent-color);
+  --color-danger-color: var(--danger-color);
 }
 
 /* Light mode */
@@ -45,6 +47,7 @@
   --sub-color: var(--color-tm-gray);
   --base-color: var(--color-tm-reddish-black);
   --accent-color: var(--color-tm-green);
+  --danger-color: var(--color-tm-red);
 
   font-family: Manjari, Inter, Avenir, Helvetica, Arial, sans-serif;
   font-synthesis: none;
@@ -61,4 +64,5 @@ html.dark {
   --sub-color: var(--color-tm-gray);
   --base-color: var(--color-tm-ivory);
   --accent-color: var(--color-tm-green);
+  --danger-color: var(--color-tm-red);
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,9 +9,19 @@ const host = process.env.TAURI_DEV_HOST;
 // https://vite.dev/config/
 export default defineConfig(async () => ({
   plugins: [tailwindcss(), vue()],
+  appType: 'mpa',
   resolve: {
     alias: {
       '@': resolve(__dirname, 'src'),
+    },
+  },
+
+  build: {
+    rollupOptions: {
+      input: {
+        main: resolve(__dirname, 'index.html'),
+        about: resolve(__dirname, 'about.html'),
+      },
     },
   },
 


### PR DESCRIPTION
close #21

### 概要

About ウィンドウの追加と、Windows/Linux 向けカスタムタイトルバーの実装。

### 変更内容

- **About ウィンドウ**（`about.html` / `src/about/`）
  - バージョン・コピーライト・GitHub リンク・OFL ライセンス表記を表示
  - バージョンクリックでリリースページへ、tato クリックで X へ遷移
  - `tauri.conf.json` で起動時に `visible: false` で生成し show/hide で開閉（コマンドスレッドからの `WebviewWindowBuilder::build()` はデッドロックを引き起こすため）
  - 閉じるボタンで hide しウィンドウを再利用可能に保持
  - `initTheme`（`src/lib/theme.ts`）でテーマを初期適用し、ストレージ変更・システムテーマ変更を監視
- **カスタムタイトルバー**（`TitleBar.vue`）
  - Windows/Linux で `decorations: false` + カスタム HTML タイトルバーに切り替え
  - macOS はネイティブメニューバーを使用（`typemeter > About typemeter`）
  - props: `showMenu`・`showMaximize`・`title` で各ウィンドウの要件に合わせて制御
  - About ウィンドウでは `showMenu=false`・`showMaximize=false`・`title="About typemeter"` で使用
  - プラットフォーム検出は `@tauri-apps/plugin-os` で行い、UA を初期値として点滅を防ぐ
- **TitleBarOffset.vue**
  - タイトルバー表示時の上部余白を補正する 0 高さスペーサー
  - Windows/Linux（カスタムタイトルバーあり）では `-mb-4`、macOS（ネイティブメニューバーのみ）では `-mb-2`
  - 値の一元管理と新規ウィンドウ追加時の対応漏れ防止のためコンポーネント化
- **テーマ**（`style.css`）
  - `danger-color`（`tm-red`）を追加し、閉じるボタンのホバー色・エラー文字色に採用

### チェック項目

- [x] Windows: タイトルバーのドラッグ・最小化/最大化/閉じるが機能するか
- [x] Windows: About ウィンドウの表示・再表示・閉じる（hide）が機能するか
- [x] macOS: ネイティブメニューバーから About ウィンドウが開くか
- [x] テーマ切り替えが About ウィンドウにリアルタイムで反映されるか
- [x] システムテーマ変更（OS 設定）が About ウィンドウに反映されるか