### PR TITLE
feat(update): GitHub Releases API で新バージョンを検知し通知する

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -36,7 +36,9 @@ const showTitleBar = ref(!navigator.userAgent.includes('Macintosh'));
 
 onMounted(async () => {
   showTitleBar.value = (await platform()) !== 'macos';
-  updateInfo.value = await checkForUpdate();
+  checkForUpdate().then((info) => {
+    updateInfo.value = info;
+  });
   unlisteners.push(
     await subscribeKeystrokeUpdate((total) => {
       todayTotal.value = total;

--- a/src/App.vue
+++ b/src/App.vue
@@ -8,12 +8,14 @@ import TabGroup from '@/components/TabGroup.vue';
 import ThemeToggle from '@/components/ThemeToggle.vue';
 import TitleBar from '@/components/TitleBar.vue';
 import TitleBarOffset from '@/components/TitleBarOffset.vue';
+import UpdateModal from '@/components/UpdateModal.vue';
 import { formatDate } from '@/lib/date';
 import {
   fetchHourlyCounts,
   subscribeKeystrokeUpdate,
   subscribeListenerError,
 } from '@/lib/keystroke';
+import { checkForUpdate, type UpdateInfo } from '@/lib/update';
 
 const todayDate = ref(formatDate(new Date()));
 const targetDate = ref(todayDate.value);
@@ -24,6 +26,7 @@ const pastTotal = ref<number | null>(null);
 const displayTotal = computed(() => (isToday.value ? todayTotal.value : pastTotal.value));
 
 const listenerError = ref<string | null>(null);
+const updateInfo = ref<UpdateInfo | null>(null);
 
 const unlisteners: Array<() => void> = [];
 
@@ -33,6 +36,7 @@ const showTitleBar = ref(!navigator.userAgent.includes('Macintosh'));
 
 onMounted(async () => {
   showTitleBar.value = (await platform()) !== 'macos';
+  updateInfo.value = await checkForUpdate();
   unlisteners.push(
     await subscribeKeystrokeUpdate((total) => {
       todayTotal.value = total;
@@ -99,6 +103,13 @@ const DAILY_GOAL = 10000;
 
     <template v-else>
       <TitleBarOffset :has-title-bar="showTitleBar" />
+      <UpdateModal
+        v-if="updateInfo"
+        :version="updateInfo.version"
+        :current-version="updateInfo.currentVersion"
+        :release-url="updateInfo.releaseUrl"
+        @dismiss="updateInfo = null"
+      />
 
       <!-- Header -->
       <header class="flex items-center px-6 h-22 shrink-0">

--- a/src/about/App.vue
+++ b/src/about/App.vue
@@ -2,12 +2,17 @@
 import { getVersion } from '@tauri-apps/api/app';
 import { openUrl } from '@tauri-apps/plugin-opener';
 import { platform } from '@tauri-apps/plugin-os';
+import { BadgeAlert, CircleCheck } from 'lucide-vue-next';
 import { onMounted, onUnmounted, ref } from 'vue';
+import SpeechBubble from '@/components/SpeechBubble.vue';
 import TitleBar from '@/components/TitleBar.vue';
 import TitleBarOffset from '@/components/TitleBarOffset.vue';
 import { initTheme } from '@/lib/theme';
+import { checkForUpdate, type UpdateInfo } from '@/lib/update';
 
 const version = ref('');
+const updateInfo = ref<UpdateInfo | null>(null);
+const updateCheckDone = ref(false);
 
 // macOS はネイティブメニューバーを使うため、Windows/Linux のみカスタムタイトルバーを表示する
 // UA による初期値で初回レンダリングのちらつきを防ぎ、plugin-os で確定する
@@ -24,6 +29,9 @@ onMounted(async () => {
   } catch {
     // version は空文字のまま表示しない
   }
+
+  updateInfo.value = await checkForUpdate();
+  updateCheckDone.value = true;
 });
 
 onUnmounted(() => {
@@ -48,15 +56,50 @@ const openGitHub = () => openUrl('https://github.com/otTATto/typemeter');
 
     <div class="flex flex-col justify-center flex-1 px-8 py-6 overflow-y-auto">
       <!-- アプリ名とバージョン -->
-      <div class="flex flex-col items-center gap-1.5 mb-6">
+      <div class="flex flex-col items-center gap-4 mb-6">
         <h1 class="text-4xl font-bold text-base-color tracking-tight">typemeter</h1>
-        <button
-          v-if="version"
-          class="text-sm text-sub-color hover:underline cursor-pointer bg-transparent border-0 p-0"
-          @click="openRelease(version)"
-        >
-          v{{ version }}
-        </button>
+        <div class="flex flex-col items-center gap-2">
+          <!-- バージョン番号（吹き出しの基準要素、button の自然幅に合わせる） -->
+          <div class="relative w-fit">
+            <!-- 吹き出しの位置決めラッパー（absolute はここに付け、SpeechBubble 自身は relative のまま保つ） -->
+            <div
+              v-if="updateCheckDone"
+              :class="[
+                'absolute bottom-full whitespace-nowrap',
+                updateInfo ? 'mb-1 ml-5' : 'ml-15',
+                { 'cursor-pointer': updateInfo },
+              ]"
+              @click="updateInfo && openUrl(updateInfo.releaseUrl)"
+            >
+              <SpeechBubble
+                :variant="updateInfo ? 'alert' : 'normal'"
+                tail="left"
+                :class="[
+                  'shadow-lg rotate-4 duration-300 ease-in-out',
+                  updateInfo ? 'hover:-translate-y-0.5' : '',
+                ]"
+              >
+                <template v-if="updateInfo">
+                  <BadgeAlert :size="12" />
+                  <span class="translate-y-0.75">Update Available! Click to Install</span>
+                </template>
+                <template v-else>
+                  <CircleCheck :size="12" />
+                  <span class="translate-y-0.75">Latest</span>
+                </template>
+              </SpeechBubble>
+            </div>
+
+            <!-- 現在バージョン（クリックでリリースページを開く） -->
+            <button
+              v-if="version"
+              class="text-sm text-sub-color hover:underline cursor-pointer bg-transparent border-0 p-0"
+              @click="openRelease(version)"
+            >
+              v{{ version }}
+            </button>
+          </div>
+        </div>
       </div>
 
       <!-- コピーライトと GitHub リンク -->

--- a/src/about/App.vue
+++ b/src/about/App.vue
@@ -30,8 +30,10 @@ onMounted(async () => {
     // version は空文字のまま表示しない
   }
 
-  updateInfo.value = await checkForUpdate();
-  updateCheckDone.value = true;
+  checkForUpdate().then((info) => {
+    updateInfo.value = info;
+    updateCheckDone.value = true;
+  });
 });
 
 onUnmounted(() => {

--- a/src/components/AppModal.vue
+++ b/src/components/AppModal.vue
@@ -1,0 +1,144 @@
+<script setup lang="ts">
+import { openUrl } from '@tauri-apps/plugin-opener';
+import { onUnmounted, ref, watch } from 'vue';
+
+/**
+ * プライマリボタンの設定
+ *
+ * - label   : ボタンのラベル
+ * - onClick : クリック時のコールバック（onClick と href は排他）
+ * - href    : 外部リンク URL（onClick と href は排他）
+ * - disabled: 非活性にするかどうか
+ * - type    : 'normal'（アクセントカラー）| 'alert'（デンジャーカラー）
+ */
+type ButtonProps = {
+  label?: string;
+  onClick?: () => void;
+  href?: string;
+  disabled?: boolean;
+  type?: 'normal' | 'alert';
+};
+
+const props = withDefaults(
+  defineProps<{
+    isOpen: boolean;
+    primaryButton?: ButtonProps;
+    closeLabel?: string;
+    closeOnBackdrop?: boolean;
+  }>(),
+  { primaryButton: undefined, closeLabel: 'とじる', closeOnBackdrop: true },
+);
+
+const emit = defineEmits<{ close: [] }>();
+
+const ANIMATION_DURATION = 300;
+
+// DOM に出しておくかどうか（アンマウントはアニメーション完了後）
+const isMounted = ref(props.isOpen);
+// 開きアニメ / 閉じアニメの状態
+const isOpened = ref(false);
+
+let animTimer: ReturnType<typeof setTimeout> | null = null;
+
+watch(
+  () => props.isOpen,
+  (val) => {
+    if (animTimer !== null) {
+      clearTimeout(animTimer);
+      animTimer = null;
+    }
+    if (val) {
+      isMounted.value = true;
+      isOpened.value = false;
+      // 次のフレームで isOpened=true にしてフェードイン開始
+      animTimer = setTimeout(() => {
+        isOpened.value = true;
+        animTimer = null;
+      }, 10);
+    } else {
+      isOpened.value = false;
+      // アニメーション完了後にアンマウント
+      animTimer = setTimeout(() => {
+        isMounted.value = false;
+        animTimer = null;
+      }, ANIMATION_DURATION);
+    }
+  },
+  { immediate: true },
+);
+
+onUnmounted(() => {
+  if (animTimer !== null) clearTimeout(animTimer);
+});
+
+const handlePrimaryHrefClick = () => {
+  if (props.primaryButton?.href) openUrl(props.primaryButton.href);
+};
+</script>
+
+<template>
+  <Teleport to="body">
+    <div
+      v-if="isMounted"
+      class="fixed inset-0 z-50 flex items-center justify-center bg-black/20 backdrop-blur transition-opacity duration-300"
+      :class="isOpened ? 'opacity-100' : 'opacity-0'"
+      @click="props.closeOnBackdrop && emit('close')"
+    >
+      <div
+        class="bg-pond-color p-[30px] w-[350px] rounded-xl transition-transform duration-300"
+        :class="isOpened ? 'scale-100' : 'scale-[0.98]'"
+        @click.stop
+      >
+        <div class="flex flex-col gap-y-[15px]">
+          <!-- 本文 -->
+          <div class="text-center">
+            <slot />
+          </div>
+
+          <!-- Primary button: 外部リンク -->
+          <a
+            v-if="primaryButton?.href"
+            class="font-bold rounded-md h-[50px] flex items-center justify-center duration-300 ease-in-out"
+            :class="[
+              primaryButton.type === 'alert'
+                ? 'bg-danger-color text-white hover:opacity-80'
+                : 'bg-accent-color text-tm-black hover:opacity-80',
+              primaryButton.disabled
+                ? 'opacity-40 pointer-events-none cursor-not-allowed'
+                : 'cursor-pointer',
+            ]"
+            @click.prevent="handlePrimaryHrefClick"
+          >
+            {{ primaryButton.label ?? '' }}
+          </a>
+
+          <!-- Primary button: アクション -->
+          <button
+            v-else-if="primaryButton?.onClick"
+            type="button"
+            :disabled="primaryButton.disabled"
+            class="font-bold rounded-md h-[50px] flex items-center justify-center duration-300 ease-in-out disabled:opacity-40 disabled:cursor-not-allowed"
+            :class="[
+              primaryButton.type === 'alert'
+                ? 'bg-danger-color text-white hover:opacity-80'
+                : 'bg-accent-color text-tm-black hover:opacity-80',
+              primaryButton.disabled ? '' : 'cursor-pointer',
+            ]"
+            @click="primaryButton.onClick()"
+          >
+            {{ primaryButton.label ?? '' }}
+          </button>
+
+          <!-- 閉じるボタン -->
+          <button
+            type="button"
+            class="text-base-color font-bold bg-sub-color/20 hover:bg-sub-color/30 cursor-pointer duration-300 ease-in-out rounded-md h-[50px] flex items-center justify-center"
+            @click="emit('close')"
+          >
+            {{ props.closeLabel }}
+          </button>
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>

--- a/src/components/AppModal.vue
+++ b/src/components/AppModal.vue
@@ -96,21 +96,21 @@ const handlePrimaryHrefClick = () => {
           </div>
 
           <!-- Primary button: 外部リンク -->
-          <a
+          <button
             v-if="primaryButton?.href"
-            class="font-bold rounded-md h-[50px] flex items-center justify-center duration-300 ease-in-out"
+            type="button"
+            :disabled="primaryButton.disabled"
+            class="font-bold rounded-md h-[50px] flex items-center justify-center duration-300 ease-in-out disabled:opacity-40 disabled:cursor-not-allowed"
             :class="[
               primaryButton.type === 'alert'
                 ? 'bg-danger-color text-white hover:opacity-80'
                 : 'bg-accent-color text-tm-black hover:opacity-80',
-              primaryButton.disabled
-                ? 'opacity-40 pointer-events-none cursor-not-allowed'
-                : 'cursor-pointer',
+              primaryButton.disabled ? '' : 'cursor-pointer',
             ]"
-            @click.prevent="handlePrimaryHrefClick"
+            @click="handlePrimaryHrefClick"
           >
-            {{ primaryButton.label ?? '' }}
-          </a>
+            <span class="translate-y-0.75">{{ primaryButton.label ?? '' }}</span>
+          </button>
 
           <!-- Primary button: アクション -->
           <button
@@ -126,7 +126,7 @@ const handlePrimaryHrefClick = () => {
             ]"
             @click="primaryButton.onClick()"
           >
-            {{ primaryButton.label ?? '' }}
+            <span class="translate-y-0.75">{{ primaryButton.label ?? '' }}</span>
           </button>
 
           <!-- 閉じるボタン -->
@@ -135,7 +135,7 @@ const handlePrimaryHrefClick = () => {
             class="text-base-color font-bold bg-sub-color/20 hover:bg-sub-color/30 cursor-pointer duration-300 ease-in-out rounded-md h-[50px] flex items-center justify-center"
             @click="emit('close')"
           >
-            {{ props.closeLabel }}
+            <span class="translate-y-0.75">{{ props.closeLabel }}</span>
           </button>
         </div>
       </div>

--- a/src/components/SpeechBubble.vue
+++ b/src/components/SpeechBubble.vue
@@ -1,0 +1,47 @@
+<script setup lang="ts">
+withDefaults(
+  defineProps<{
+    variant?: 'normal' | 'alert';
+    tail?: 'center' | 'left' | 'right';
+  }>(),
+  { variant: 'normal', tail: 'center' },
+);
+</script>
+
+<template>
+  <div
+    class="speech-bubble relative flex items-center gap-1 px-2 py-1 rounded-full text-xs font-bold"
+    :class="[
+      variant === 'alert' ? 'bg-danger-color text-white' : 'bg-accent-color text-tm-black',
+      `tail-${tail}`,
+    ]"
+  >
+    <slot />
+  </div>
+</template>
+
+<style scoped>
+.speech-bubble::after {
+  content: '';
+  position: absolute;
+  bottom: -4px;
+  width: 8px;
+  height: 8px;
+  background-color: inherit;
+}
+
+.speech-bubble.tail-center::after {
+  left: 50%;
+  transform: translateX(-50%) rotate(45deg);
+}
+
+.speech-bubble.tail-left::after {
+  left: 20%;
+  transform: translateX(-50%) rotate(45deg);
+}
+
+.speech-bubble.tail-right::after {
+  left: 80%;
+  transform: translateX(-50%) rotate(45deg);
+}
+</style>

--- a/src/components/UpdateModal.vue
+++ b/src/components/UpdateModal.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+import AppModal from '@/components/AppModal.vue';
+
+const props = defineProps<{
+  version: string;
+  currentVersion: string;
+  releaseUrl: string;
+}>();
+
+const emit = defineEmits<{
+  dismiss: [];
+}>();
+</script>
+
+<template>
+  <AppModal
+    :is-open="true"
+    :primary-button="{ label: 'Open Install Page', href: props.releaseUrl }"
+    :close-on-backdrop="false"
+    close-label="Later"
+    @close="emit('dismiss')"
+  >
+    <h3 class="text-2xl font-bold">Update Available</h3>
+    <p class="m-0">
+      New version
+      <span class="font-bold text-accent-color">v{{ props.version }}</span>
+      is available! 🎉
+    </p>
+    <p class="text-sub-color text-sm">
+      current version:
+      <span class="text-accent-color">v{{ props.currentVersion }}</span>
+    </p>
+  </AppModal>
+</template>

--- a/src/lib/update.ts
+++ b/src/lib/update.ts
@@ -27,7 +27,7 @@ const parseVersion = (v: string): ParsedVersion => {
  * @function latest が current より新しいバージョンかどうかを判定する
  *
  * NOTE:
- *   - プレリリース同士の比較は辞書順（例: "beta.2" > "beta.10" の誤検知が起きうる）
+ *   - プレリリースのセグメントが数値の場合は数値比較、それ以外は辞書順
  *   - リリース版 (pre=null) はプレリリース (pre!=null) より新しいとみなす
  */
 const isNewerThan = (latest: ParsedVersion, current: ParsedVersion): boolean => {
@@ -37,7 +37,21 @@ const isNewerThan = (latest: ParsedVersion, current: ParsedVersion): boolean => 
   if (latest.pre === null && current.pre !== null) return true;
   if (latest.pre !== null && current.pre === null) return false;
   if (latest.pre === null && current.pre === null) return false;
-  return (latest.pre ?? '') > (current.pre ?? '');
+
+  const lParts = (latest.pre ?? '').split('.');
+  const cParts = (current.pre ?? '').split('.');
+  for (let i = 0; i < Math.max(lParts.length, cParts.length); i++) {
+    const l = lParts[i];
+    const c = cParts[i];
+    if (l === undefined) return false;
+    if (c === undefined) return true;
+    if (l === c) continue;
+    const lNum = Number(l);
+    const cNum = Number(c);
+    if (!isNaN(lNum) && !isNaN(cNum)) return lNum > cNum;
+    return l > c;
+  }
+  return false;
 };
 
 /**
@@ -47,7 +61,13 @@ const isNewerThan = (latest: ParsedVersion, current: ParsedVersion): boolean => 
  */
 export const checkForUpdate = async (): Promise<UpdateInfo | null> => {
   try {
-    const [currentVersion, response] = await Promise.all([getVersion(), fetch(RELEASES_API_URL)]);
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 5000);
+    const [currentVersion, response] = await Promise.all([
+      getVersion(),
+      fetch(RELEASES_API_URL, { signal: controller.signal }),
+    ]);
+    clearTimeout(timeoutId);
 
     if (!response.ok) return null;
 

--- a/src/lib/update.ts
+++ b/src/lib/update.ts
@@ -1,0 +1,70 @@
+import { getVersion } from '@tauri-apps/api/app';
+
+const RELEASES_API_URL = 'https://api.github.com/repos/otTATto/typemeter/releases?per_page=1';
+const RELEASES_FALLBACK_URL = 'https://github.com/otTATto/typemeter/releases';
+
+export type UpdateInfo = {
+  version: string;
+  currentVersion: string;
+  releaseUrl: string;
+};
+
+type ParsedVersion = {
+  major: number;
+  minor: number;
+  patch: number;
+  pre: string | null;
+};
+
+const parseVersion = (v: string): ParsedVersion => {
+  const clean = v.replace(/^v/, '');
+  const [main, pre = null] = clean.split(/-(.+)/, 2) as [string, string | undefined];
+  const [major = 0, minor = 0, patch = 0] = main.split('.').map(Number);
+  return { major, minor, patch, pre: pre ?? null };
+};
+
+/**
+ * @function latest が current より新しいバージョンかどうかを判定する
+ *
+ * NOTE:
+ *   - プレリリース同士の比較は辞書順（例: "beta.2" > "beta.10" の誤検知が起きうる）
+ *   - リリース版 (pre=null) はプレリリース (pre!=null) より新しいとみなす
+ */
+const isNewerThan = (latest: ParsedVersion, current: ParsedVersion): boolean => {
+  if (latest.major !== current.major) return latest.major > current.major;
+  if (latest.minor !== current.minor) return latest.minor > current.minor;
+  if (latest.patch !== current.patch) return latest.patch > current.patch;
+  if (latest.pre === null && current.pre !== null) return true;
+  if (latest.pre !== null && current.pre === null) return false;
+  if (latest.pre === null && current.pre === null) return false;
+  return (latest.pre ?? '') > (current.pre ?? '');
+};
+
+/**
+ * @function GitHub Releases API で最新リリースを取得し、現バージョンより新しければ返す
+ *
+ * NOTE: ネットワークエラーや API エラー時は null を返す（アプリの動作を妨げない）
+ */
+export const checkForUpdate = async (): Promise<UpdateInfo | null> => {
+  try {
+    const [currentVersion, response] = await Promise.all([getVersion(), fetch(RELEASES_API_URL)]);
+
+    if (!response.ok) return null;
+
+    const data: unknown[] = await response.json();
+    const latest = data[0] as Record<string, string> | undefined;
+    const latestTag = latest?.tag_name ?? '';
+
+    if (!latestTag) return null;
+
+    if (!isNewerThan(parseVersion(latestTag), parseVersion(currentVersion))) return null;
+
+    return {
+      version: latestTag.replace(/^v/, ''),
+      currentVersion,
+      releaseUrl: latest?.html_url ?? RELEASES_FALLBACK_URL,
+    };
+  } catch {
+    return null;
+  }
+};


### PR DESCRIPTION
close #20

### 背景

issue #19（ワンクリックアップデート）の前段として、新バージョンの検知と通知を実装する。
コード署名証明書が不要な方法として、GitHub Releases API を使ったポーリング方式を採用した。

### 概要

起動時に GitHub Releases API を叩き、現バージョンより新しいリリースがあればメインウィンドウのモーダルと About ウィンドウの吹き出しで通知する。

### 変更内容

- `src/lib/update.ts` を新規追加
  - GitHub Releases API (`releases?per_page=1`) で最新リリースを取得
  - semver 比較（プレリリース対応）で新バージョン判定
  - ネットワークエラー・API エラー時は null を返し、アプリ動作を妨げない
- `src/components/AppModal.vue` を新規追加
  - フェード＋スケールアニメーション付きの汎用モーダルコンポーネント
  - プライマリボタン（外部リンク／アクション）・閉じるボタン・バックドロップクリックを設定で制御可能
- `src/components/UpdateModal.vue` を新規追加
  - AppModal を薄くラップしたアップデート通知専用モーダル
  - 新バージョン番号・現バージョン番号を表示し、インストールページへ誘導
- `src/components/SpeechBubble.vue` を新規追加
  - `variant`（normal / alert）と `tail`（center / left / right）を指定できる汎用吹き出しコンポーネント
- `src/App.vue` を修正
  - 起動時に `checkForUpdate()` を実行し、更新があれば UpdateModal を表示
- `src/about/App.vue` を修正
  - バージョン名の上に吹き出しで「✓ Latest」または「! Update Available」を表示
  - アップデートがある場合は吹き出しをクリックでインストールページを開く

### チェック項目

- [ ] メインウィンドウで更新通知モーダルが表示される（新バージョンがある場合）
- [ ] モーダルの「Open Install Page」でブラウザが開く
- [ ] モーダルの「Later」で閉じる（バックドロップクリックでは閉じない）
- [ ] About ウィンドウで吹き出しが「✓ Latest」を表示する（最新の場合）
- [ ] About ウィンドウで吹き出しが「! Update Available」を表示し、クリックでブラウザが開く（新バージョンがある場合）
- [ ] ネットワーク不通時もアプリが正常起動する

### 備考

- semver のプレリリース比較は辞書順のため、`beta.10 > beta.9` が正しく判定されない既知の制限あり（通常リリースには影響なし）